### PR TITLE
Split interrupts

### DIFF
--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -9,6 +9,8 @@ use crate::mm;
 
 #[cfg(target_arch = "riscv64")]
 pub type MemoryImpl = riscv64::sv39::PageTable;
+#[cfg(target_arch = "riscv64")]
+pub type InterruptsImpl = riscv64::interrupts::Interrupts;
 
 pub fn new_arch() -> impl Architecture {
     cfg_if! {
@@ -24,8 +26,6 @@ pub fn new_arch() -> impl Architecture {
 
 pub trait Architecture {
     unsafe extern "C" fn _start() -> !;
-
-    fn init_interrupts(&mut self);
 }
 
 pub trait ArchitectureMemory {
@@ -39,4 +39,9 @@ pub trait ArchitectureMemory {
         perms: mm::Permissions,
     );
     fn reload(&mut self);
+}
+
+pub trait ArchitectureInterrupts {
+    fn new() -> Self;
+    fn init_interrupts(&self);
 }

--- a/src/arch/riscv64/interrupts.rs
+++ b/src/arch/riscv64/interrupts.rs
@@ -1,6 +1,7 @@
 use crate::arch::riscv64::registers;
 use crate::arch::ArchitectureInterrupts;
 use crate::drivers::plic::plic_handler;
+use core::arch::asm;
 
 #[no_mangle]
 static mut g_higher_trap_handler: *const () = 0 as *const ();

--- a/src/arch/riscv64/interrupts.rs
+++ b/src/arch/riscv64/interrupts.rs
@@ -1,0 +1,157 @@
+use crate::arch::riscv64::registers;
+use crate::arch::ArchitectureInterrupts;
+use crate::drivers::plic::plic_handler;
+
+#[no_mangle]
+static mut g_higher_trap_handler: *const () = 0 as *const ();
+
+static mut INTERRUPT_VECTOR: &[extern "C" fn()] = &[
+    undefined_handler,
+    undefined_handler,
+    undefined_handler,
+    undefined_handler,
+    undefined_handler,
+    undefined_handler,
+    undefined_handler,
+    undefined_handler,
+    undefined_handler,
+    plic_handler,
+];
+
+pub struct Interrupts {}
+
+impl Interrupts {
+    fn set_higher_trap_handler(&self, higher_trap_handler: fn(cause: usize)) {
+        unsafe {
+            g_higher_trap_handler = higher_trap_handler as *const ();
+        }
+    }
+}
+
+impl ArchitectureInterrupts for Interrupts {
+    fn new() -> Self {
+        Self {}
+    }
+
+    fn init_interrupts(&self) {
+        registers::set_sstatus_sie();
+        registers::set_sie_ssie();
+        registers::set_sie_seie();
+        registers::set_stvec(trap_handler as usize);
+        self.set_higher_trap_handler(trap_dispatch);
+    }
+}
+
+fn is_interrupt(cause: usize) -> bool {
+    (cause >> 63) == 1
+}
+
+fn trap_dispatch(cause: usize) {
+    if is_interrupt(cause) {
+        let exception_code = cause & !(1 << 63);
+        unsafe {
+            INTERRUPT_VECTOR[exception_code]();
+        }
+    } else {
+        panic!("Exception not implemented yet");
+    }
+}
+
+extern "C" fn undefined_handler() {
+    panic!("Interruption is not handled yet");
+}
+
+#[naked]
+#[no_mangle]
+#[repr(align(4))]
+unsafe extern "C" fn trap_handler() {
+    asm!(
+        "
+        addi sp, sp, -0x100
+
+        sd x31, 0x100(sp)
+        sd x30, 0xf8(sp)
+        sd x29, 0xf0(sp)
+        sd x28, 0xd8(sp)
+        sd x27, 0xd0(sp)
+        sd x26, 0xc8(sp)
+        sd x25, 0xc0(sp)
+        sd x24, 0xb8(sp)
+        sd x23, 0xb0(sp)
+        sd x22, 0xa8(sp)
+        sd x21, 0xa0(sp)
+        sd x20, 0x98(sp)
+        sd x19, 0x90(sp)
+        sd x18, 0x88(sp)
+        sd x17, 0x80(sp)
+        sd x16, 0x78(sp)
+        sd x15, 0x70(sp)
+        sd x14, 0x68(sp)
+        sd x13, 0x60(sp)
+        sd x12, 0x58(sp)
+        sd x11, 0x50(sp)
+        sd x10, 0x48(sp)
+        sd x9, 0x40(sp)
+        sd x8, 0x38(sp)
+        sd x7, 0x30(sp)
+        sd x6, 0x28(sp)
+        sd x5, 0x20(sp)
+        sd x4, 0x18(sp)
+        sd x3, 0x10(sp)
+        sd x2, 0x8(sp)
+        sd x1, 0x0(sp)
+
+        // mv a0, sp // Pointer on stack for the register struct
+        // csrr a1, sepc
+        // csrr a2, stval
+        // csrr a3, scause
+        // csrr a5, sstatus
+
+        csrr a0, scause
+        ld t0, g_higher_trap_handler
+        jalr t0
+
+        csrr t0, sepc
+        addi t0, t0, 4
+        csrw sepc, t0
+
+        ld x1, 0x0(sp)
+        ld x2, 0x8(sp)
+        ld x3, 0x10(sp)
+        ld x4, 0x18(sp)
+        ld x5, 0x20(sp)
+        ld x6, 0x28(sp)
+        ld x7, 0x30(sp)
+        ld x8, 0x38(sp)
+        ld x9, 0x40(sp)
+        ld x10, 0x48(sp)
+        ld x11, 0x50(sp)
+        ld x12, 0x58(sp)
+        ld x13, 0x60(sp)
+        ld x14, 0x68(sp)
+        ld x15, 0x70(sp)
+        ld x16, 0x78(sp)
+        ld x17, 0x80(sp)
+        ld x18, 0x88(sp)
+        ld x19, 0x90(sp)
+        ld x20, 0x98(sp)
+        ld x21, 0xa0(sp)
+        ld x22, 0xa8(sp)
+        ld x23, 0xb0(sp)
+        ld x24, 0xb8(sp)
+        ld x25, 0xc0(sp)
+        ld x26, 0xc8(sp)
+        ld x27, 0xd0(sp)
+        ld x28, 0xd8(sp)
+        ld x29, 0xf0(sp)
+        ld x30, 0xf8(sp)
+        ld x31, 0x100(sp)
+
+        addi sp, sp, 0x100
+
+        sret",
+        options(noreturn)
+    );
+    // Obviously this isn't done, we need to jump back to the previous context before the
+    // interrupt using mpp/spp and mepc/sepc.
+}

--- a/src/arch/riscv64/mod.rs
+++ b/src/arch/riscv64/mod.rs
@@ -1,59 +1,14 @@
 use super::Architecture;
-use crate::drivers::plic::plic_handler;
 
+pub mod interrupts;
+pub mod registers;
 pub mod sv39;
-
-#[no_mangle]
-static mut g_higher_trap_handler: *const () = 0 as *const ();
-
-static mut INTERRUPT_VECTOR: &[extern "C" fn()] = &[
-    undefined_handler,
-    undefined_handler,
-    undefined_handler,
-    undefined_handler,
-    undefined_handler,
-    undefined_handler,
-    undefined_handler,
-    undefined_handler,
-    undefined_handler,
-    plic_handler,
-];
 
 pub struct Riscv64 {}
 
 impl Riscv64 {
     pub fn new() -> Self {
         Self {}
-    }
-
-    fn set_sstatus_sie(&self) {
-        unsafe {
-            asm!("csrrs zero, sstatus, {}", in(reg)1 << 1);
-        }
-    }
-
-    fn set_sie_ssie(&self) {
-        unsafe {
-            asm!("csrrs zero, sie, {}", in(reg)1 << 1);
-        }
-    }
-
-    fn set_sie_seie(&self) {
-        unsafe {
-            asm!("csrrs zero, sie, {}", in(reg)1 << 9);
-        }
-    }
-
-    fn set_stvec(&self, addr: usize) {
-        unsafe {
-            asm!("csrw stvec, {}", in(reg)(addr));
-        }
-    }
-
-    fn set_higher_trap_handler(&mut self, higher_trap_handler: fn(cause: usize)) {
-        unsafe {
-            g_higher_trap_handler = higher_trap_handler as *const ();
-        }
     }
 }
 
@@ -63,126 +18,4 @@ impl Architecture for Riscv64 {
     unsafe extern "C" fn _start() -> ! {
         asm!("la sp, STACK_START", "call k_main", options(noreturn));
     }
-
-    fn init_interrupts(&mut self) {
-        self.set_sstatus_sie();
-        self.set_sie_ssie();
-        self.set_sie_seie();
-        self.set_stvec(trap_handler as usize);
-        self.set_higher_trap_handler(trap_dispatch);
-    }
-}
-
-fn is_interrupt(cause: usize) -> bool {
-    (cause >> 63) == 1
-}
-
-fn trap_dispatch(cause: usize) {
-    if is_interrupt(cause) {
-        let exception_code = cause & !(1 << 63);
-        unsafe {
-            INTERRUPT_VECTOR[exception_code]();
-        }
-    } else {
-        panic!("Exception not implemented yet");
-    }
-}
-
-extern "C" fn undefined_handler() {
-    panic!("Interruption is not handled yet");
-}
-
-#[naked]
-#[no_mangle]
-#[repr(align(4))]
-unsafe extern "C" fn trap_handler() {
-    asm!(
-        "
-        addi sp, sp, -0x100
-
-        sd x31, 0x100(sp)
-        sd x30, 0xf8(sp)
-        sd x29, 0xf0(sp)
-        sd x28, 0xd8(sp)
-        sd x27, 0xd0(sp)
-        sd x26, 0xc8(sp)
-        sd x25, 0xc0(sp)
-        sd x24, 0xb8(sp)
-        sd x23, 0xb0(sp)
-        sd x22, 0xa8(sp)
-        sd x21, 0xa0(sp)
-        sd x20, 0x98(sp)
-        sd x19, 0x90(sp)
-        sd x18, 0x88(sp)
-        sd x17, 0x80(sp)
-        sd x16, 0x78(sp)
-        sd x15, 0x70(sp)
-        sd x14, 0x68(sp)
-        sd x13, 0x60(sp)
-        sd x12, 0x58(sp)
-        sd x11, 0x50(sp)
-        sd x10, 0x48(sp)
-        sd x9, 0x40(sp)
-        sd x8, 0x38(sp)
-        sd x7, 0x30(sp)
-        sd x6, 0x28(sp)
-        sd x5, 0x20(sp)
-        sd x4, 0x18(sp)
-        sd x3, 0x10(sp)
-        sd x2, 0x8(sp)
-        sd x1, 0x0(sp)
-
-        // mv a0, sp // Pointer on stack for the register struct
-        // csrr a1, sepc
-        // csrr a2, stval
-        // csrr a3, scause
-        // csrr a5, sstatus
-
-        csrr a0, scause
-        ld t0, g_higher_trap_handler
-        jalr t0
-
-        csrr t0, sepc
-        addi t0, t0, 4
-        csrw sepc, t0
-
-        ld x1, 0x0(sp)
-        ld x2, 0x8(sp)
-        ld x3, 0x10(sp)
-        ld x4, 0x18(sp)
-        ld x5, 0x20(sp)
-        ld x6, 0x28(sp)
-        ld x7, 0x30(sp)
-        ld x8, 0x38(sp)
-        ld x9, 0x40(sp)
-        ld x10, 0x48(sp)
-        ld x11, 0x50(sp)
-        ld x12, 0x58(sp)
-        ld x13, 0x60(sp)
-        ld x14, 0x68(sp)
-        ld x15, 0x70(sp)
-        ld x16, 0x78(sp)
-        ld x17, 0x80(sp)
-        ld x18, 0x88(sp)
-        ld x19, 0x90(sp)
-        ld x20, 0x98(sp)
-        ld x21, 0xa0(sp)
-        ld x22, 0xa8(sp)
-        ld x23, 0xb0(sp)
-        ld x24, 0xb8(sp)
-        ld x25, 0xc0(sp)
-        ld x26, 0xc8(sp)
-        ld x27, 0xd0(sp)
-        ld x28, 0xd8(sp)
-        ld x29, 0xf0(sp)
-        ld x30, 0xf8(sp)
-        ld x31, 0x100(sp)
-
-        addi sp, sp, 0x100
-
-        sret",
-        options(noreturn)
-    );
-    // Obviously this isn't done, we need to jump back to the previous context before the
-    // interrupt using mpp/spp and mepc/sepc.
 }

--- a/src/arch/riscv64/mod.rs
+++ b/src/arch/riscv64/mod.rs
@@ -1,3 +1,5 @@
+use core::arch::asm;
+
 use super::Architecture;
 
 pub mod interrupts;

--- a/src/arch/riscv64/registers.rs
+++ b/src/arch/riscv64/registers.rs
@@ -1,0 +1,23 @@
+pub fn set_sstatus_sie() {
+    unsafe {
+        asm!("csrrs zero, sstatus, {}", in(reg)1 << 1);
+    }
+}
+
+pub fn set_sie_ssie() {
+    unsafe {
+        asm!("csrrs zero, sie, {}", in(reg)1 << 1);
+    }
+}
+
+pub fn set_sie_seie() {
+    unsafe {
+        asm!("csrrs zero, sie, {}", in(reg)1 << 9);
+    }
+}
+
+pub fn set_stvec(addr: usize) {
+    unsafe {
+        asm!("csrw stvec, {}", in(reg)(addr));
+    }
+}

--- a/src/arch/riscv64/registers.rs
+++ b/src/arch/riscv64/registers.rs
@@ -1,3 +1,5 @@
+use core::arch::asm;
+
 pub fn set_sstatus_sie() {
     unsafe {
         asm!("csrrs zero, sstatus, {}", in(reg)1 << 1);

--- a/src/arch/riscv64/sv39.rs
+++ b/src/arch/riscv64/sv39.rs
@@ -3,6 +3,7 @@ use crate::arch::ArchitectureMemory;
 use crate::mm;
 use core::convert::TryInto;
 use modular_bitfield::{bitfield, prelude::*};
+use core::arch::asm;
 
 #[repr(C)]
 pub struct VAddr {

--- a/src/interrupt_manager/mod.rs
+++ b/src/interrupt_manager/mod.rs
@@ -1,0 +1,17 @@
+use crate::arch;
+
+pub struct InterruptManager<T: arch::ArchitectureInterrupts> {
+    arch: T,
+}
+
+impl<T: arch::ArchitectureInterrupts> InterruptManager<T> {
+    pub fn new() -> Self {
+        let arch = T::new();
+
+        Self { arch }
+    }
+
+    pub fn init_interrupts(&self) {
+        self.arch.init_interrupts()
+    }
+}

--- a/src/kernel_serial.rs
+++ b/src/kernel_serial.rs
@@ -1,4 +1,5 @@
 use core::fmt::{self, Write};
+use core::arch::asm;
 
 use crate::drivers::ns16550::{Ns16550, QEMU_VIRT_BASE_ADDRESS};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@
 
 mod arch;
 mod drivers;
+mod interrupt_manager;
 mod kernel_serial;
 mod mm;
 mod utils;
@@ -19,18 +20,14 @@ mod kernel_tests;
 use drivers::ns16550::*;
 use drivers::plic;
 
-use arch::Architecture;
-
 #[no_mangle]
 fn k_main() -> ! {
     #[cfg(test)]
     ktests_launch();
 
-    let mut arch = arch::new_arch();
+    let _arch = arch::new_arch();
 
     kprintln!("GoOSe is booting");
-
-    arch.init_interrupts();
 
     // Enable Serial interrupts
     plic::init(plic::QEMU_VIRT_PLIC_BASE_ADDRESS);
@@ -46,7 +43,12 @@ fn k_main() -> ! {
     let mut memory = mm::MemoryManager::<arch::MemoryImpl>::new();
     memory.map_address_space();
 
-    kprintln!("Virtual memory enabled!");
+    kprintln!("[OK] Setup virtual memory");
+
+    let interrupts = interrupt_manager::InterruptManager::<arch::InterruptsImpl>::new();
+    interrupts.init_interrupts();
+
+    kprintln!("[OK] Enable interrupts");
 
     loop {
         unsafe {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![no_main]
-#![feature(asm)]
 #![feature(fn_align)]
 #![feature(naked_functions)]
 #![feature(custom_test_frameworks)]
@@ -19,6 +18,7 @@ mod kernel_tests;
 
 use drivers::ns16550::*;
 use drivers::plic;
+use core::arch::asm;
 
 #[no_mangle]
 fn k_main() -> ! {


### PR DESCRIPTION
Split architecture interrupt handling from base `Architecture` trait and adds a `InterruptsManager`

Names are quite bad, feel free to propose other names the traits, struct fields and variables