### PR TITLE
Fix doc build with CI job

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,23 @@
+name: Doc
+
+on: pull_request
+
+jobs:
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # For now goOSe is RISC-V only
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            target: riscv64gc-unknown-none-elf
+            components: clippy
+            override: true
+
+      - name: Run gen_cargo.sh
+        run: ./gen_cargo.sh riscv64_qemuvirt
+
+      - name: Build doc
+        run: cargo doc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cortex-m"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac919ef424449ec8c08d515590ce15d9262c0ca5f0da5b0c901e971a3b783b3"
+checksum = "37ff967e867ca14eba0c34ac25cd71ea98c678e741e3915d923999bb2fe7c826"
 dependencies = [
  "bare-metal",
  "bitfield",
@@ -121,9 +121,9 @@ checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -136,9 +136,9 @@ checksum = "220eb94f40665452ab6114bf8a8d86aa1fd41c6dbfaa4ab71b5912c8adb80389"
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
@@ -175,9 +175,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -1,7 +1,11 @@
-#[cfg(drv_ns16550)]
+//! This module stores all drivers strictly necessary for the kernel.
+//! As we want the kernel as small as possible, each driver is hidden behind a feature flag in
+//! order to get compiled only is the platform requires it
+
+#[doc(cfg(drv_ns16550))]
 pub mod ns16550;
 
-#[cfg(drv_plic)]
+#[doc(cfg(drv_plic))]
 pub mod plic;
 
 // TODO: - have a driver trait

--- a/src/drivers/ns16550.rs
+++ b/src/drivers/ns16550.rs
@@ -1,5 +1,5 @@
-/// The datasheet used to write this is:
-/// http://caro.su/msx/ocm_de1/16550.pdf
+//! Driver for the NS16550 UART chip.
+//! The datasheet used to write this is: <http://caro.su/msx/ocm_de1/16550.pdf>
 
 pub const QEMU_VIRT_BASE_ADDRESS: usize = 0x10000000;
 pub const QEMU_VIRT_NS16550_INTERRUPT_NUMBER: u16 = 10;

--- a/src/drivers/plic.rs
+++ b/src/drivers/plic.rs
@@ -1,5 +1,5 @@
-/// Driver fot the RISC-V Platform-Level Interrupt Controller
-/// Documentation: https://github.com/riscv/riscv-plic-spec/blob/master/riscv-plic.adoc
+//! Driver fot the RISC-V Platform-Level Interrupt Controller
+//! <https://github.com/riscv/riscv-plic-spec/blob/master/riscv-plic.adoc>
 
 pub const QEMU_VIRT_PLIC_BASE_ADDRESS: usize = 0xc000000;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![feature(doc_cfg)]
 #![feature(fn_align)]
 #![feature(naked_functions)]
 #![feature(custom_test_frameworks)]
@@ -16,9 +17,9 @@ mod utils;
 #[cfg(test)]
 mod kernel_tests;
 
+use core::arch::asm;
 use drivers::ns16550::*;
 use drivers::plic;
-use core::arch::asm;
 
 #[no_mangle]
 fn k_main() -> ! {


### PR DESCRIPTION
Doc was failing to compile because a lot of of `use` where hidden
behind `#[cfg()]`. Using `#![feature(doc_cfg)]` we can now use `#[doc(cfg())]`
to actually use the items when building doc

Fixes #87 