### PR TITLE
refactor(mm): put the map/reload_pt methods into their own trait

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ extern "C" fn k_main(_core_id: usize, device_tree_ptr: usize) -> ! {
     }
     plic.set_threshold(0);
 
-    let mut memory = mm::MemoryManager::<arch::MemoryImpl>::new(&arch);
+    let mut memory = mm::MemoryManagement::<arch::MemoryImpl>::new(&arch);
     memory.map_address_space();
 
     kprintln!("[OK] Setup virtual memory");

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -23,7 +23,7 @@ bitflags! {
 
 pub trait MemoryManager {
     fn map(&mut self, to: usize, from: usize, perms: Permissions);
-    fn reload_pt(&mut self);
+    fn reload_page_table(&mut self);
 
 }
 
@@ -106,7 +106,7 @@ impl<'alloc, T: arch::ArchitectureMemory> MemoryManagement<'alloc, T> {
             Permissions::READ | Permissions::WRITE,
         );
 
-        self.arch.reload();
+        self.reload_page_table();
     }
 }
 
@@ -115,7 +115,7 @@ impl<T: arch::ArchitectureMemory> MemoryManager for MemoryManagement<'_, T> {
         self.arch.map(&mut self.page_manager, to, from, perms)
     }
 
-    fn reload_pt(&mut self) {
+    fn reload_page_table(&mut self) {
         self.arch.reload();
     }
 }


### PR DESCRIPTION
Why was this done:
Before the split, if you wanted to pass the memory manager to a
function, you had the specify MemoryManger's type parameter ie:
  ```rust
  do_something(mm: &mut MemoryManager<arch::MemoryImpl>)
  ```
That required exposing the underlying MemoryImpl to the user (the
function) but the whole ideo of the MemoryManager was abstracting all
that.

Now since the functionaly is exposed via a trait, a follow only needs
the follwing:
```rust
  do_something(mm: &mut dyn MemoryManager)
  ```
It doesn't know a single thing about the underlying implementation.