### PR TITLE
Create multiple binaries so that each board has its own k_main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,7 @@ panic = "abort"
 
 [profile.release]
 panic = "abort"
+
+[[bin]]
+name = "riscv64_qemuvirt"
+path = "src/riscv64_qemuvirt_main.rs"

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -1,25 +1,16 @@
 #[cfg(target_arch = "arm")]
-mod arm32;
+pub mod arm32;
 #[cfg(target_arch = "riscv64")]
-mod riscv64;
+pub mod riscv64;
 
 use crate::mm;
 
 use cfg_if::cfg_if;
 use static_assertions::assert_impl_all;
 
-#[cfg(target_arch = "riscv64")]
-pub type ArchImpl = riscv64::Riscv64;
-#[cfg(target_arch = "riscv64")]
-pub type ArchInterruptsImpl = riscv64::interrupts::Interrupts;
-#[cfg(target_arch = "riscv64")]
-pub type MemoryImpl = riscv64::sv39::PageTable;
-#[cfg(target_arch = "riscv64")]
-pub type InterruptsImpl = riscv64::interrupts::Interrupts;
-
-assert_impl_all!(ArchImpl: Architecture);
-assert_impl_all!(MemoryImpl: ArchitectureMemory);
-assert_impl_all!(InterruptsImpl: ArchitectureInterrupts);
+assert_impl_all!(crate::ArchImpl: Architecture);
+assert_impl_all!(crate::MemoryImpl: ArchitectureMemory);
+assert_impl_all!(crate::InterruptsImpl: ArchitectureInterrupts);
 
 pub fn new_arch(info: usize) -> impl Architecture {
     cfg_if! {

--- a/src/executable/elf.rs
+++ b/src/executable/elf.rs
@@ -1,6 +1,5 @@
 use core::iter::Iterator;
 
-use crate::arch;
 use crate::arch::ArchitectureMemory;
 use crate::mm;
 
@@ -66,7 +65,7 @@ impl<'a> Elf<'a> {
         }
     }
 
-    pub fn load(&self, page_table: &mut arch::MemoryImpl, pmm: &mut mm::PhysicalMemoryManager) {
+    pub fn load(&self, page_table: &mut crate::MemoryImpl, pmm: &mut mm::PhysicalMemoryManager) {
         let page_size = pmm.page_size();
 
         for segment in self.segments() {
@@ -108,7 +107,7 @@ impl<'a> Elf<'a> {
                     pmm,
                     mm::PAddr::from(usize::from(physical_pages) + page_offset),
                     mm::VAddr::from(
-                        arch::MemoryImpl::align_down(virtual_pages as usize) + page_offset,
+                        crate::MemoryImpl::align_down(virtual_pages as usize) + page_offset,
                     ),
                     perms,
                 );

--- a/src/interrupt_manager/mod.rs
+++ b/src/interrupt_manager/mod.rs
@@ -1,13 +1,12 @@
-use crate::arch;
 use crate::arch::ArchitectureInterrupts;
 
 pub struct InterruptManager {
-    arch: arch::InterruptsImpl,
+    arch: crate::InterruptsImpl,
 }
 
 impl InterruptManager {
     pub fn new() -> Self {
-        let arch = arch::InterruptsImpl::new();
+        let arch = crate::InterruptsImpl::new();
 
         Self { arch }
     }

--- a/src/kernel_tests.rs
+++ b/src/kernel_tests.rs
@@ -17,10 +17,10 @@ static mut TEST_CONTEXT: Option<TestContext> = None;
 
 pub struct TestContext<'alloc> {
     device_tree_address: usize,
-    pub arch: arch::ArchImpl,
-    pub arch_interrupts: arch::ArchInterruptsImpl,
+    pub arch: crate::ArchImpl,
+    pub arch_interrupts: crate::InterruptsImpl,
     pub pmm: mm::PhysicalMemoryManager,
-    pub page_table: &'alloc mut arch::MemoryImpl,
+    pub page_table: &'alloc mut crate::MemoryImpl,
 }
 
 impl<'alloc> TestContext<'alloc> {
@@ -30,7 +30,7 @@ impl<'alloc> TestContext<'alloc> {
         TestContext {
             device_tree_address,
             arch,
-            arch_interrupts: arch::ArchInterruptsImpl::new(),
+            arch_interrupts: crate::InterruptsImpl::new(),
             pmm,
             page_table,
         }
@@ -51,15 +51,15 @@ impl<'alloc> TestContext<'alloc> {
     fn build_context_data(
         device_tree_address: usize,
     ) -> (
-        arch::ArchImpl,
+        crate::ArchImpl,
         mm::PhysicalMemoryManager,
-        &'alloc mut arch::MemoryImpl,
+        &'alloc mut crate::MemoryImpl,
     ) {
-        let arch = arch::ArchImpl::new(device_tree_address);
+        let arch = crate::ArchImpl::new(device_tree_address);
         let mut pmm =
-            mm::PhysicalMemoryManager::from_arch_info(&arch, arch::MemoryImpl::get_page_size());
+            mm::PhysicalMemoryManager::from_arch_info(&arch, crate::MemoryImpl::get_page_size());
 
-        let page_table = arch::MemoryImpl::new(&mut pmm);
+        let page_table = crate::MemoryImpl::new(&mut pmm);
         mm::map_address_space(&arch, page_table, &mut pmm);
 
         (arch, pmm, page_table)

--- a/src/mm/mod.rs
+++ b/src/mm/mod.rs
@@ -95,7 +95,7 @@ pub fn is_reserved_page(base: usize, arch: &impl arch::Architecture) -> bool {
 
 fn map_memory_rw(
     arch: &impl arch::Architecture,
-    page_table: &mut arch::MemoryImpl,
+    page_table: &mut crate::MemoryImpl,
     pmm: &mut PhysicalMemoryManager,
     page_size: usize,
 ) {
@@ -115,7 +115,7 @@ fn map_memory_rw(
     });
 }
 
-fn map_kernel_rwx(mm: &mut arch::MemoryImpl, pmm: &mut PhysicalMemoryManager, page_size: usize) {
+fn map_kernel_rwx(mm: &mut crate::MemoryImpl, pmm: &mut PhysicalMemoryManager, page_size: usize) {
     let kernel_start = unsafe { utils::external_symbol_value(&KERNEL_START) };
     let kernel_end = unsafe { utils::external_symbol_value(&KERNEL_END) };
     let kernel_end_align = ((kernel_end + page_size - 1) / page_size) * page_size;
@@ -132,7 +132,7 @@ fn map_kernel_rwx(mm: &mut arch::MemoryImpl, pmm: &mut PhysicalMemoryManager, pa
 
 pub fn map_address_space(
     arch: &impl arch::Architecture,
-    page_table: &mut arch::MemoryImpl,
+    page_table: &mut crate::MemoryImpl,
     pmm: &mut PhysicalMemoryManager,
 ) {
     let page_size = pmm.page_size();

--- a/src/riscv64_qemuvirt_main.rs
+++ b/src/riscv64_qemuvirt_main.rs
@@ -36,7 +36,7 @@ pub type MemoryImpl = arch::riscv64::sv39::PageTable;
 extern "C" fn k_main(_core_id: usize, device_tree_ptr: usize) -> ! {
     #[cfg(test)]
     {
-        crate::kernel_tests::init(device_tree_ptr);
+        kernel_tests::init(device_tree_ptr);
         ktests_launch();
     }
 
@@ -56,8 +56,8 @@ extern "C" fn k_main(_core_id: usize, device_tree_ptr: usize) -> ! {
     plic.set_threshold(0);
 
     let mut pmm =
-        mm::PhysicalMemoryManager::from_arch_info(&arch, crate::MemoryImpl::get_page_size());
-    let page_table = crate::MemoryImpl::new(&mut pmm);
+        mm::PhysicalMemoryManager::from_arch_info(&arch, MemoryImpl::get_page_size());
+    let page_table = MemoryImpl::new(&mut pmm);
     mm::map_address_space(&arch, page_table, &mut pmm);
 
     kprintln!("[OK] Setup virtual memory");


### PR DESCRIPTION
In order to make board bring-up simpler, we initialize everything in a different .rs for each board.
For example, `riscv64_qemuvirt_main.rs` sets the interrupts type, the memory impl, etc... 