### PR TITLE
refactor: Rename ArchitectureMemory -> PagingImpl

### DIFF
--- a/kernel/src/executable/elf.rs
+++ b/kernel/src/executable/elf.rs
@@ -1,7 +1,7 @@
 use core::iter::Iterator;
 
-use crate::arch_mem::ArchitectureMemory;
 use crate::mm;
+use crate::paging::PagingImpl;
 
 use goblin;
 use goblin::elf::header::header64::Header;

--- a/kernel/src/kernel_tests.rs
+++ b/kernel/src/kernel_tests.rs
@@ -5,8 +5,8 @@ use core::panic::PanicInfo;
 use crate::arch;
 use crate::arch::Architecture;
 use crate::arch::ArchitectureInterrupts;
-use crate::arch_mem::ArchitectureMemory;
 use crate::mm;
+use crate::paging::PagingImpl;
 use crate::{kprint, kprintln};
 
 use drivers::qemuexit::QemuExit;
@@ -60,7 +60,7 @@ impl TestContext {
         let device_tree = crate::device_tree::DeviceTree::new(device_tree_address);
         let mut pmm = mm::PhysicalMemoryManager::from_device_tree(
             &device_tree,
-            crate::MemoryImpl::get_page_size(),
+            crate::PagingImpl::get_page_size(),
         );
 
         let page_table = mm::map_address_space(

--- a/kernel/src/paging.rs
+++ b/kernel/src/paging.rs
@@ -13,7 +13,7 @@ impl From<TryFromIntError> for Error {
     }
 }
 
-pub trait ArchitectureMemory {
+pub trait PagingImpl {
     fn new<'alloc>(allocator: &mut mm::PhysicalMemoryManager) -> &'alloc mut Self;
 
     fn get_page_size() -> usize;
@@ -60,8 +60,8 @@ mod tests {
     use super::*;
     use crate::kernel_tests::TestContext;
 
-    struct ArchitectureMemoryDummy {}
-    impl ArchitectureMemory for ArchitectureMemoryDummy {
+    struct PagingImplDummy {}
+    impl PagingImpl for PagingImplDummy {
         fn new<'alloc>(_allocator: &mut mm::PhysicalMemoryManager) -> &'alloc mut Self {
             unreachable!("We will never use this, we just need the compiler to be happy");
         }
@@ -103,11 +103,11 @@ mod tests {
 
     #[test_case]
     fn align_down(_ctx: &mut TestContext) {
-        assert!(ArchitectureMemoryDummy::align_down(0x1042) == 0x1000);
+        assert!(PagingImplDummy::align_down(0x1042) == 0x1000);
     }
 
     #[test_case]
     fn align_up(_ctx: &mut TestContext) {
-        assert!(ArchitectureMemoryDummy::align_up(0x1042) == 0x2000);
+        assert!(PagingImplDummy::align_up(0x1042) == 0x2000);
     }
 }

--- a/kernel/src/riscv64_qemuvirt_main.rs
+++ b/kernel/src/riscv64_qemuvirt_main.rs
@@ -12,7 +12,6 @@
 compile_error!("Must be compiled as riscv64");
 
 mod arch;
-mod arch_mem;
 mod device_tree;
 mod executable;
 mod interrupt_manager;
@@ -20,6 +19,7 @@ mod kernel_console;
 #[cfg(test)]
 mod kernel_tests;
 mod mm;
+mod paging;
 mod utils;
 
 use core::arch::asm;
@@ -27,11 +27,11 @@ use drivers::ns16550::*;
 use drivers::plic;
 
 use arch::Architecture;
-use arch_mem::ArchitectureMemory;
+use paging::PagingImpl as _;
 
 pub type ArchImpl = arch::riscv64::Riscv64;
 pub type InterruptsImpl = arch::riscv64::interrupts::Interrupts;
-pub type MemoryImpl = arch::riscv64::sv39::PageTable;
+pub type PagingImpl = arch::riscv64::sv39::PageTable;
 pub type ConsoleImpl = Ns16550;
 
 pub const UART_ADDR: usize = 0x1000_0000;
@@ -64,7 +64,7 @@ extern "C" fn k_main(_core_id: usize, device_tree_ptr: usize) -> ! {
     plic.set_threshold(0);
 
     let mut pmm =
-        mm::PhysicalMemoryManager::from_device_tree(&device_tree, MemoryImpl::get_page_size());
+        mm::PhysicalMemoryManager::from_device_tree(&device_tree, PagingImpl::get_page_size());
     let pagetable = mm::map_address_space(
         &device_tree,
         &mut pmm,


### PR DESCRIPTION
I propose renaming that awful typename (and useless module) to PagingImpl.

The crate also holds the global type alias `crate::PagingImpl` but everything works out well thanks to namespaces.
Also it is likely we are going ot re-add generics soon, so `crate::PagingImpl` would disappear.