### PR TITLE
pmm: make discovery of memory regions *much* faster

### DIFF
--- a/kernel/boards/riscv64_qemuvirt.ld
+++ b/kernel/boards/riscv64_qemuvirt.ld
@@ -2,8 +2,7 @@ ENTRY(_start)
 
 SECTIONS
 {
-    /* . = 0x80200000; */
-    . = 0x40100000;
+    . = 0x80200000;
 
     KERNEL_START = . ;
     .text : {

--- a/kernel/src/aarch64_qemuvirt_main.rs
+++ b/kernel/src/aarch64_qemuvirt_main.rs
@@ -77,6 +77,12 @@ extern "C" fn k_main(_device_tree_ptr: usize) -> ! {
     );
     mm.set_kernel_pagetable(pagetable);
 
+    // ???:
+    // why do we pass the pagetable after into the mm ?
+    //     (can we pass it at initialization)
+    // - also when we map, we reload the page table, enabling the MMU (SCTLR_EL1.M)
+    //   shouldn't that be separate ? ie map just put it in the pagetable, then we can manually reload it / enable paging ?
+
     kprintln!("Kernel has been initialized");
 
     mm.kernel_map(

--- a/kernel/src/device_tree.rs
+++ b/kernel/src/device_tree.rs
@@ -15,8 +15,8 @@ impl DeviceTree {
         }
     }
 
-    pub fn is_used(&self, page: usize) -> bool {
-        page >= self.addr && page < self.addr + self.total_size
+    pub fn memory_region(&self) -> (usize, usize) {
+        (self.addr, self.addr + self.total_size)
     }
 
     pub fn for_all_memory_regions<F: FnMut(&mut dyn Iterator<Item = (usize, usize)>)>(

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -141,6 +141,15 @@ pub fn is_kernel_page(base: usize) -> bool {
     base >= kernel_start && base < kernel_end
 }
 
+pub fn kernel_memory_region() -> (usize, usize) {
+    unsafe {
+        (
+            utils::external_symbol_value(&KERNEL_START),
+            utils::external_symbol_value(&KERNEL_END),
+        )
+    }
+}
+
 pub fn is_reserved_page(base: usize, device_tree: &DeviceTree) -> bool {
     let mut is_res = false;
 
@@ -246,6 +255,7 @@ pub fn map_address_space(
     let page_table = crate::PagingImpl::new(mm);
     let page_size = mm.page_size();
 
+    // ???: aren't we mapping the same stuff here as in pmm_pages.for_each...
     device_tree.for_all_memory_regions(|regions| {
         regions
             .flat_map(|(base, size)| (base..base + size).step_by(page_size))


### PR DESCRIPTION
Before, we had a lot of closures we would repeatadly chain to figure out which memory is what. Now we only take into account "available" memory region, region that are not reserved, don't have the device tree, don't have the kernel there etc...

Thanks to this the code now only iterates over memory which we is allocatable (reading/writing to it must not break the kernel).