### PR TITLE
Use globals for the storage of the kernel's pagetable, physical memory manager and console

### DIFF
--- a/aarch64_qemuvirt/src/main.rs
+++ b/aarch64_qemuvirt/src/main.rs
@@ -1,17 +1,13 @@
 #![no_std]
 #![no_main]
-// #![feature(custom_test_frameworks)]
-// #![test_runner(crate::kernel_tests::runner)]
-// #![reexport_test_harness_main = "ktests_launch"]
 
 #[cfg(not(target_arch = "aarch64"))]
 compile_error!("Must be compiled as aarch64");
 
+use kernel::paging::PagingImpl;
 use kernel::drivers::gicv2::GicV2;
 use kernel::drivers::pl011::Pl011;
-use kernel::drivers::Console;
-
-use core::arch::asm;
+use kernel::drivers::{Driver, Console};
 
 use cortex_a::asm;
 
@@ -21,14 +17,10 @@ const DTB_ADDR: usize = 0x4000_0000;
 extern "C" fn k_main(_device_tree_ptr: usize) -> ! {
     kernel::arch::aarch64::Aarch64::disable_fp_trap();
 
-    kernel::kernel_console::init(Pl011::new(0x0900_0000));
-    kernel::kprintln!("hello!");
+    static PL011: Pl011 = Pl011::new(0x0900_0000);
+    kernel::globals::set_console(&PL011);
 
-    #[cfg(test)]
-    {
-        kernel_tests::init(DTB_ADDR);
-        ktests_launch();
-    }
+    kernel::kprintln!("hello, I am GoOSe!");
 
     let mut gic = GicV2::new(0x8000000, 0x8010000);
     gic.enable(30); // Physical timer
@@ -44,33 +36,25 @@ extern "C" fn k_main(_device_tree_ptr: usize) -> ! {
         asm::barrier::dsb(asm::barrier::SY);
     };
 
-    let device_tree_ptr = DTB_ADDR;
-    let device_tree = kernel::device_tree::DeviceTree::new(device_tree_ptr);
-    //
-    let pmm = kernel::mm::PhysicalMemoryManager::from_device_tree(&device_tree, 4096);
-    let mut mm = kernel::mm::MemoryManager::new(pmm);
-    let pagetable = kernel::mm::map_address_space(
-        &device_tree,
-        &mut mm,
-        &[kernel::kernel_console::get_console()],
-    );
-    mm.set_kernel_pagetable(pagetable);
+    let device_tree = kernel::device_tree::DeviceTree::new(DTB_ADDR);
 
-    // ???:
-    // why do we pass the pagetable after into the mm ?
-    //     (can we pass it at initialization)
-    // - also when we map, we reload the page table, enabling the MMU (SCTLR_EL1.M)
-    //   shouldn't that be separate ? ie map just put it in the pagetable, then we can manually reload it / enable paging ?
+    kernel::globals::PHYSICAL_MEMORY_MANAGER.lock(|pmm| pmm.init_from_device_tree(&device_tree, 4096));
+    kernel::mm::map_address_space(&device_tree, &[&PL011]);
 
-    kernel::kprintln!("Kernel has been initialized");
+    kernel::kprintln!("PMM has been initialized with the device tree... check");
+    kernel::kprintln!("kernel's address space has been mapped into the kernel's pagetable... check");
+    kernel::kprintln!("Kernel initialization should be about done.");
 
-    mm.kernel_map(
-        0x0900_0000,
-        0x0450_0000,
-        kernel::mm::Permissions::READ | kernel::mm::Permissions::WRITE,
-    );
-    let mut uart = Pl011::new(0x0450_0000);
-    uart.write("Uart remaped");
+    kernel::kprintln!("Testing the remapping capabilities of our pagetable...");
+    kernel::globals::KERNEL_PAGETABLE.lock(|pagetable| {
+        pagetable.map(
+            0x0900_0000.into(),
+            0x0450_0000.into(),
+            kernel::mm::Permissions::READ | kernel::mm::Permissions::WRITE,
+        );
+    });
+    let uart = Pl011::new(0x0450_0000);
+    uart.write("Uart remaped, if you see this, it works !!!");
 
     loop {}
 }

--- a/drivers/src/init_cell.rs
+++ b/drivers/src/init_cell.rs
@@ -1,0 +1,23 @@
+use core::cell::UnsafeCell;
+
+pub struct InitCell<T: Sized> {
+    data: UnsafeCell<T>,
+}
+
+impl<T> InitCell<T> {
+    pub const fn new(data: T) -> Self {
+        Self { data: UnsafeCell::new(data) }
+    }
+
+    pub fn set<'a>(&'a self, f: impl FnOnce(&'a mut T)) {
+        let data = unsafe { &mut *self.data.get() };
+        f(data)
+    }
+
+    pub fn get<'a>(&'a self) -> &'a T {
+        unsafe { &*self.data.get() }
+    }
+}
+
+unsafe impl<T: Send> Send for InitCell<T> {}
+unsafe impl<T: Send> Sync for InitCell<T> {}

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -2,6 +2,10 @@
 
 #![no_std]
 
+mod lock;
+pub mod init_cell;
+
+pub mod null_uart;
 pub mod ns16550;
 pub mod pl011;
 pub mod qemuexit;
@@ -15,6 +19,6 @@ pub trait Driver {
     fn get_address_range(&self) -> Option<(usize, usize)>;
 }
 
-pub trait Console {
-    fn write(&mut self, data: &str);
+pub trait Console: Driver {
+    fn write(&self, data: &str);
 }

--- a/drivers/src/lock.rs
+++ b/drivers/src/lock.rs
@@ -1,0 +1,23 @@
+use core::cell::UnsafeCell;
+
+pub struct Lock<T: Sized> {
+    data: UnsafeCell<T>,
+}
+
+impl<T> Lock<T> {
+    pub const fn new(data: T) -> Self {
+        Self {
+            data: UnsafeCell::new(data),
+        }
+    }
+
+    pub fn lock<'a, R>(&'a self, f: impl FnOnce(&'a mut T) -> R) -> R {
+        // TODO: actually lock something...
+        let data = unsafe { &mut *self.data.get() };
+
+        f(data)
+    }
+}
+
+unsafe impl<T> Send for Lock<T> where T: Sized + Send {}
+unsafe impl<T> Sync for Lock<T> where T: Sized + Send {}

--- a/drivers/src/ns16550.rs
+++ b/drivers/src/ns16550.rs
@@ -3,15 +3,20 @@
 
 use super::Console;
 use super::Driver;
+use super::lock::Lock;
 
 const TRANSMITTER_HOLDING_REGISTER: usize = 0;
 const _INTERRUPT_ENABLE_REGISTER: usize = 1;
 
 pub struct Ns16550 {
+    inner: Lock<Ns16550Inner>,
+}
+
+struct Ns16550Inner {
     base_register_address: usize,
 }
 
-impl Ns16550 {
+impl Ns16550Inner {
     pub const fn new(base_register_address: usize) -> Self {
         Self {
             base_register_address,
@@ -45,17 +50,29 @@ impl Ns16550 {
     }
 }
 
+impl Ns16550 {
+    pub fn new(base: usize) -> Self {
+        Self {
+            inner: Lock::new(Ns16550Inner::new(base))
+        }
+    }
+}
+
 impl Driver for Ns16550 {
     fn get_address_range(&self) -> Option<(usize, usize)> {
         // Base address + max register offset
-        Some((self.base_register_address, 0b111))
+        self.inner.lock(|ns16550| {
+            Some((ns16550.base_register_address, 0b111))
+        })
     }
 }
 
 impl Console for Ns16550 {
-    fn write(&mut self, data: &str) {
-        for byte in data.bytes() {
-            self.write_transmitter_holding_reg(byte);
-        }
+    fn write(&self, data: &str) {
+        self.inner.lock(|ns16550| {
+            for byte in data.bytes() {
+                ns16550.write_transmitter_holding_reg(byte);
+            }
+        })
     }
 }

--- a/drivers/src/null_uart.rs
+++ b/drivers/src/null_uart.rs
@@ -1,0 +1,22 @@
+use super::{Driver, Console};
+
+#[derive(Debug)]
+pub struct NullUart;
+
+impl NullUart {
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Console for NullUart {
+    fn write(&self, _data: &str) {
+        // Does nothing, just a placeholder while a real uart is not in place.
+    }
+}
+
+impl Driver for NullUart {
+    fn get_address_range(&self) -> Option<(usize, usize)> {
+        None
+    }
+}

--- a/drivers/src/pl011.rs
+++ b/drivers/src/pl011.rs
@@ -1,12 +1,17 @@
 use super::Console;
 use super::Driver;
+use super::lock::Lock;
 
 pub struct Pl011 {
+    inner: Lock<Pl011Inner>,
+}
+
+struct Pl011Inner {
     base: usize,
 }
 
-impl Pl011 {
-    pub fn new(base: usize) -> Self {
+impl Pl011Inner {
+    pub const fn new(base: usize) -> Self {
         Self { base }
     }
 
@@ -33,12 +38,22 @@ impl Pl011 {
 impl Driver for Pl011 {
     fn get_address_range(&self) -> Option<(usize, usize)> {
         // Base address, max register offset
-        Some((self.base, 0xFFC))
+        self.inner.lock(|pl011| Some((pl011.base, 0xFFC)))
     }
 }
 
 impl Console for Pl011 {
-    fn write(&mut self, data: &str) {
-        data.bytes().for_each(|b| self.putc(b))
+    fn write(&self, data: &str) {
+        self.inner.lock(|pl011| {
+            data.bytes().for_each(|b| pl011.putc(b))
+        });
+    }
+}
+
+impl Pl011 {
+    pub const fn new(base: usize) -> Self {
+        Self {
+            inner: Lock::new(Pl011Inner::new(base))
+        }
     }
 }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 [dependencies]
 cfg-if = "1.0"
 static_assertions = "1.1.0"
+once_cell = { version = "1.16.0", default-features = false }
 modular-bitfield = "0.11"
 bitflags = "1.3"
 fdt = "0.1"

--- a/kernel/src/globals.rs
+++ b/kernel/src/globals.rs
@@ -1,0 +1,39 @@
+use core::cell::UnsafeCell;
+use once_cell::unsync::OnceCell;
+use crate::lock::Lock;
+
+use crate::mm;
+
+use drivers::init_cell::InitCell;
+use drivers::Console;
+
+static NULL_CONSOLE: drivers::null_uart::NullUart = drivers::null_uart::NullUart::new();
+
+pub static CONSOLE: InitCell<&'static (dyn drivers::Console + Sync)> = InitCell::new(&NULL_CONSOLE);
+pub static PHYSICAL_MEMORY_MANAGER: Lock<mm::PhysicalMemoryManager> = Lock::new(mm::PhysicalMemoryManager::new());
+
+pub static KERNEL_PAGETABLE: Lock<crate::PagingImpl> = Lock::new(crate::PagingImpl::zeroed());
+
+pub enum KernelState {
+    EarlyInit,
+    MmuEnabledInit,
+}
+
+impl KernelState {
+    pub fn is_mmu_enabled(&self) -> bool {
+        match self {
+            Self::MmuEnabledInit => true,
+            _ => false,
+        }
+    }
+}
+
+pub static mut STATE: KernelState = KernelState::EarlyInit;
+
+pub fn set_console(new_console: &'static (dyn drivers::Console + Sync)) {
+    CONSOLE.set(|console| *console = new_console);
+}
+
+pub fn get_console() -> &'static dyn drivers::Console {
+    *CONSOLE.get()
+}

--- a/kernel/src/kernel_console.rs
+++ b/kernel/src/kernel_console.rs
@@ -1,26 +1,12 @@
 use core::fmt::{self, Write};
 
+use crate::globals;
+
 use drivers::Console;
 use drivers::Driver;
 
-pub static mut STDOUT_UART: Option<crate::ConsoleImpl> = None;
-
-pub fn init(uart: crate::ConsoleImpl) {
-    unsafe { STDOUT_UART = Some(uart) };
-}
-
-pub fn get_console() -> &'static dyn Driver {
-    if let Some(console) = unsafe { &STDOUT_UART } {
-        return console;
-    }
-
-    panic!("Cannot get address range of uninitialized console");
-}
-
 fn write(data: &str) {
-    if let Some(console) = unsafe { &mut STDOUT_UART } {
-        console.write(data);
-    }
+    globals::get_console().write(data);
 }
 
 struct KernelConsoleWriter;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,12 +1,20 @@
 #![no_std]
 #![feature(naked_functions)]
 #![feature(fn_align)]
+#![feature(const_mut_refs)]
+#![feature(slice_ptr_get)]
+#![feature(const_ptr_as_ref)]
+#![feature(const_slice_from_raw_parts_mut)]
+#![feature(iterator_try_collect)]
+#![feature(const_for)]
 
 pub mod arch;
 pub mod device_tree;
 pub mod kernel_console;
 pub mod mm;
 pub mod paging;
+pub mod globals;
+mod lock;
 mod utils;
 
 // TODO: redo the unit tests with Mockall
@@ -31,3 +39,4 @@ cfg_if::cfg_if! {
 static_assertions::assert_impl_all!(ArchImpl: arch::Architecture);
 static_assertions::assert_impl_all!(InterruptsImpl: arch::ArchitectureInterrupts);
 static_assertions::assert_impl_all!(PagingImpl: paging::PagingImpl);
+static_assertions::assert_impl_all!(ConsoleImpl: drivers::Console);

--- a/kernel/src/lock.rs
+++ b/kernel/src/lock.rs
@@ -1,0 +1,23 @@
+use core::cell::UnsafeCell;
+
+pub struct Lock<T: Sized> {
+    data: UnsafeCell<T>,
+}
+
+impl<T> Lock<T> {
+    pub const fn new(data: T) -> Self {
+        Self {
+            data: UnsafeCell::new(data),
+        }
+    }
+
+    pub fn lock<'a, R>(&'a self, f: impl FnOnce(&'a mut T) -> R) -> R {
+        // TODO: actually lock something...
+        let data = unsafe { &mut *self.data.get() };
+
+        f(data)
+    }
+}
+
+unsafe impl<T> Send for Lock<T> where T: Sized + Send {}
+unsafe impl<T> Sync for Lock<T> where T: Sized + Send {}

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -1,11 +1,13 @@
 mod physical_memory_manager;
 pub use physical_memory_manager::{AllocatorError, PhysicalMemoryManager};
 
+use drivers::Driver;
 use crate::device_tree::DeviceTree;
 use crate::mm;
 use crate::paging;
 use crate::paging::PagingImpl as _;
 use crate::utils;
+use crate::globals;
 
 use bitflags::bitflags;
 
@@ -23,9 +25,9 @@ bitflags! {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct VAddr {
-    addr: usize,
+    pub addr: usize,
 }
 
 impl core::convert::From<usize> for VAddr {
@@ -69,67 +71,6 @@ impl<T> core::convert::From<&PAddr> for *mut T {
     }
 }
 
-pub struct MemoryManager {
-    pmm: PhysicalMemoryManager,
-    kernel_pagetable: Option<KernelPageTable>,
-}
-
-impl MemoryManager {
-    pub fn new(pmm: PhysicalMemoryManager) -> Self {
-        Self {
-            pmm,
-            kernel_pagetable: None,
-        }
-    }
-
-    pub fn get_kernel_pagetable(&mut self) -> Option<&mut KernelPageTable> {
-        self.kernel_pagetable.as_mut()
-    }
-
-    pub fn set_kernel_pagetable(&mut self, kernel_pagetable: KernelPageTable) {
-        self.kernel_pagetable = Some(kernel_pagetable);
-    }
-
-    pub fn alloc_pages(&mut self, page_count: usize) -> Result<PAddr, AllocatorError> {
-        let pages = self.pmm.alloc_pages(page_count)?;
-        let page_size = self.page_size();
-
-        if let Some(kernel_pagetable) = &mut self.kernel_pagetable {
-            for i in 0..page_count {
-                let offset = i * page_size;
-
-                kernel_pagetable
-                    .identity_map(pages.addr + offset, Permissions::READ | Permissions::WRITE)
-                    .unwrap();
-            }
-
-            kernel_pagetable.reload();
-        }
-
-        Ok(pages)
-    }
-
-    pub fn page_size(&self) -> usize {
-        self.pmm.page_size()
-    }
-
-    pub fn kernel_map(&mut self, paddr: usize, vaddr: usize, perms: Permissions) {
-        // This one is a bit tricky. The pagetable is stored in self. But when calling map() on a
-        // pagetable, you need to provide a MemoryManager (self) in order to map potential
-        // alloction required by the mapping.
-        // The borrow checker is not happy with self.kernel_pagetable.map(self, ...) and I agree
-        // with him. But on this case, we are just using the MemoryManager to bundle both a
-        // pagetable and an allocator together. Since we could have passed this as tupple instead,
-        // one could argue that this is "safe"ish.
-        // See you when we realize it was not "safe"ish
-        let kernel_pgt =
-            &mut unsafe { &mut *(self.kernel_pagetable.as_mut().unwrap() as *mut KernelPageTable) };
-
-        kernel_pgt.map(self, paddr, vaddr, perms);
-        kernel_pgt.reload();
-    }
-}
-
 pub fn is_kernel_page(base: usize) -> bool {
     let (kernel_start, kernel_end) = unsafe {
         (
@@ -164,15 +105,14 @@ pub fn is_reserved_page(base: usize, device_tree: &DeviceTree) -> bool {
     is_res
 }
 
-fn map_kernel_rwx(pagetable: &mut crate::PagingImpl, mm: &mut MemoryManager) {
-    let page_size = mm.page_size();
+fn map_kernel_rwx(pagetable: &mut crate::PagingImpl) {
+    let page_size = crate::PagingImpl::get_page_size();
     let kernel_start = unsafe { utils::external_symbol_value(&KERNEL_START) };
     let kernel_end = unsafe { utils::external_symbol_value(&KERNEL_END) };
     let kernel_end_align = ((kernel_end + page_size - 1) / page_size) * page_size;
 
     for addr in (kernel_start..kernel_end_align).step_by(page_size) {
         if let Err(e) = pagetable.map(
-            mm,
             PAddr::from(addr),
             VAddr::from(addr),
             Permissions::READ | Permissions::WRITE | Permissions::EXECUTE,
@@ -187,18 +127,17 @@ pub struct KernelPageTable(&'static mut crate::PagingImpl);
 impl KernelPageTable {
     pub fn identity_map(&mut self, addr: usize, perms: Permissions) -> Result<(), paging::Error> {
         self.0
-            .map_noalloc(PAddr::from(addr), VAddr::from(addr), perms)
+            .map(PAddr::from(addr), VAddr::from(addr), perms)
     }
 
     pub fn map(
         &mut self,
-        mm: &mut mm::MemoryManager,
         paddr: usize,
         vaddr: usize,
         perms: Permissions,
     ) -> Result<(), paging::Error> {
         self.0
-            .map(mm, PAddr::from(paddr), VAddr::from(vaddr), perms)
+            .map(PAddr::from(paddr), VAddr::from(vaddr), perms)
     }
 
     pub fn reload(&mut self) {
@@ -212,23 +151,25 @@ impl KernelPageTable {
 pub struct UserPageTable(&'static mut crate::PagingImpl);
 
 impl UserPageTable {
-    pub fn new(mm: &mut mm::MemoryManager) -> Result<Self, paging::Error> {
-        let page_table = crate::PagingImpl::new(mm);
+    pub fn new() -> Result<Self, paging::Error> {
+        let page_table = crate::PagingImpl::new();
 
-        map_kernel_rwx(page_table, mm);
+        // TODO: do we really need this:
+        // - aarch64
+        //      thx to TTBR0_EL1/TTBR0_EL0 I don't see why we'd need it
+        map_kernel_rwx(page_table);
 
         Ok(UserPageTable(page_table))
     }
 
     pub fn map(
         &mut self,
-        mm: &mut mm::MemoryManager,
         paddr: usize,
         vaddr: usize,
         perms: Permissions,
     ) -> Result<(), paging::Error> {
         self.0
-            .map(mm, PAddr::from(paddr), VAddr::from(vaddr), perms)
+            .map(PAddr::from(paddr), VAddr::from(vaddr), perms)
     }
 
     pub fn align_down(&self, addr: usize) -> usize {
@@ -249,32 +190,35 @@ impl UserPageTable {
 
 pub fn map_address_space(
     device_tree: &DeviceTree,
-    mm: &mut MemoryManager,
-    drivers: &[&dyn drivers::Driver],
-) -> KernelPageTable {
-    let page_table = crate::PagingImpl::new(mm);
-    let page_size = mm.page_size();
+    drivers: &[&dyn Driver],
+) {
+    // TODO: return a result from map_address_space !!!
+    let page_table: &mut crate::PagingImpl = globals::KERNEL_PAGETABLE.lock(|pt| pt);
 
-    // ???: aren't we mapping the same stuff here as in pmm_pages.for_each...
+    let page_size = crate::PagingImpl::get_page_size();
+
+    /// Add entries/descriptors in the pagetable for all of accessible memory regions.
+    /// That way in the future, mapping those entries won't require any memory allocations,
+    /// just settings the entry to valid and filling up the bits.
     device_tree.for_all_memory_regions(|regions| {
         regions
             .flat_map(|(base, size)| (base..base + size).step_by(page_size))
             .for_each(|page_base| {
-                if let Err(e) = page_table.add_invalid_entry(mm, VAddr::from(page_base)) {
+                if let Err(e) = page_table.add_invalid_entry(VAddr::from(page_base)) {
                     panic!("Failed to map address space: {:?}", e);
                 }
             })
     });
 
-    map_kernel_rwx(page_table, mm);
+    map_kernel_rwx(page_table);
 
     drivers
         .iter()
-        .filter_map(|drv| drv.get_address_range())
+        .map(|drv| drv.get_address_range())
+        .filter_map(|drv| drv)
         .flat_map(|(base, len)| (base..(base + len)).step_by(page_size))
         .for_each(|page| {
             if let Err(e) = page_table.map(
-                mm,
                 PAddr::from(page),
                 VAddr::from(page),
                 Permissions::READ | Permissions::WRITE,
@@ -283,21 +227,22 @@ pub fn map_address_space(
             }
         });
 
-    let metadata_pages = mm.pmm.metadata_pages();
-    let allocated_pages = mm.pmm.allocated_pages();
-    let pmm_pages = metadata_pages.chain(allocated_pages);
-    pmm_pages.for_each(|page| {
-        // All pmm pages are in DRAM so they are already in the pagetable
-        if let Err(e) = page_table.map_noalloc(
-            PAddr::from(page),
-            VAddr::from(page),
-            Permissions::READ | Permissions::WRITE,
-        ) {
-            panic!("Failed to map address space: {:?}", e);
-        }
-    });
+    globals::PHYSICAL_MEMORY_MANAGER
+        .lock(|pmm| {
+            let metadata_pages = pmm.metadata_pages();
+            let allocated_pages = pmm.allocated_pages();
+            let pmm_pages = metadata_pages.chain(allocated_pages);
+            pmm_pages.for_each(|page| {
+                // All pmm pages are part of DRAM so they are already in the pagetable.
+                // Therefore no allocations should be made.
+                page_table.map(
+                    PAddr::from(page),
+                    VAddr::from(page),
+                    Permissions::READ | Permissions::WRITE,
+                ).unwrap()
+            });
+        });
 
+    unsafe { globals::STATE = globals::KernelState::MmuEnabledInit };
     page_table.reload();
-
-    KernelPageTable(page_table)
 }

--- a/kernel/src/mm/physical_memory_manager.rs
+++ b/kernel/src/mm/physical_memory_manager.rs
@@ -1,6 +1,9 @@
 use crate::device_tree::DeviceTree;
+use crate::paging::PagingImpl;
 use crate::mm;
 use crate::mm::PAddr;
+use crate::globals;
+use crate::paging;
 use core::mem;
 
 /// A range similar to core::ops::Range but that is copyable.
@@ -75,6 +78,7 @@ pub enum AllocatorError {
     OutOfMemory,
 }
 
+#[derive(Debug)]
 pub struct PhysicalMemoryManager {
     metadata: &'static mut [PhysicalPage],
     page_size: usize,
@@ -221,8 +225,18 @@ impl PhysicalMemoryManager {
         all_regions
     }
 
+    pub const fn new() -> Self {
+        let metadata = unsafe {
+            core::slice::from_raw_parts_mut(core::ptr::NonNull::<PhysicalPage>::dangling().as_ptr(), 0) };
+
+        Self {
+            metadata,
+            page_size: 0,
+        }
+    }
+
     /// Initialize a [`PageAllocator`] from the device tree.
-    pub fn from_device_tree(device_tree: &DeviceTree, page_size: usize) -> Self {
+    pub fn init_from_device_tree(&mut self, device_tree: &DeviceTree, page_size: usize) {
         let available_regions = Self::available_memory_regions::<10>(device_tree, page_size);
 
         assert!(
@@ -262,10 +276,8 @@ impl PhysicalMemoryManager {
             metadata[i] = page;
         }
 
-        Self {
-            metadata,
-            page_size,
-        }
+        self.metadata = metadata;
+        self.page_size = page_size;
     }
 
     pub fn alloc_pages(&mut self, page_count: usize) -> Result<PAddr, AllocatorError> {
@@ -302,6 +314,30 @@ impl PhysicalMemoryManager {
         }
 
         Err(AllocatorError::OutOfMemory)
+    }
+
+    pub fn alloc_rw_pages(&mut self, page_count: usize) -> Result<PAddr, AllocatorError> {
+        // If there is a kernel pagetable, identity map the pages.
+        // Not sure this is the best idea, but I would say it follows the
+        // principle of least astonishment.
+        //
+        let first_page = self.alloc_pages(page_count)?;
+        let addr: usize = first_page.into();
+
+
+        if unsafe { globals::STATE.is_mmu_enabled() } {
+            globals::KERNEL_PAGETABLE.lock(|kernel_pt| {
+                for page_addr in (addr..(addr + page_count * self.page_size())).step_by(self.page_size()) {
+                    kernel_pt
+                        .map(page_addr.into(), page_addr.into(), mm::Permissions::READ | mm::Permissions::WRITE)
+                        .unwrap();
+                    }
+            });
+        }
+
+        // Bit weird, when we have a KERNEL_PAGETABLE this is a VAddr, but PAddr
+        // otherwise.
+        Ok(PAddr::from(addr))
     }
 
     pub fn page_size(&self) -> usize {

--- a/kernel/src/paging.rs
+++ b/kernel/src/paging.rs
@@ -14,7 +14,7 @@ impl From<TryFromIntError> for Error {
 }
 
 pub trait PagingImpl {
-    fn new<'alloc>(mm: &mut mm::MemoryManager) -> &'alloc mut Self;
+    fn new<'alloc>() -> &'alloc mut Self;
 
     fn get_page_size() -> usize;
 
@@ -32,14 +32,6 @@ pub trait PagingImpl {
 
     fn map(
         &mut self,
-        mm: &mut mm::MemoryManager,
-        pa: mm::PAddr,
-        va: mm::VAddr,
-        perms: mm::Permissions,
-    ) -> Result<(), Error>;
-
-    fn map_noalloc(
-        &mut self,
         pa: mm::PAddr,
         va: mm::VAddr,
         perms: mm::Permissions,
@@ -47,7 +39,6 @@ pub trait PagingImpl {
 
     fn add_invalid_entry(
         &mut self,
-        mm: &mut mm::MemoryManager,
         vaddr: mm::VAddr,
     ) -> Result<(), Error>;
 
@@ -62,7 +53,7 @@ mod tests {
 
     struct PagingImplDummy {}
     impl PagingImpl for PagingImplDummy {
-        fn new<'alloc>(_mm: &mut mm::MemoryManager) -> &'alloc mut Self {
+        fn new<'alloc>() -> &'alloc mut Self {
             unreachable!("We will never use this, we just need the compiler to be happy");
         }
 
@@ -71,16 +62,6 @@ mod tests {
         }
 
         fn map(
-            &mut self,
-            _mm: &mut mm::MemoryManager,
-            _pa: mm::PAddr,
-            _va: mm::VAddr,
-            _perms: mm::Permissions,
-        ) -> Result<(), Error> {
-            unreachable!("We will never use this, we just need the compiler to be happy");
-        }
-
-        fn map_noalloc(
             &mut self,
             _pa: mm::PAddr,
             _va: mm::VAddr,


### PR DESCRIPTION
probably has lot of useless code, also has debug prints by the bucketload