### PR TITLE
Use globals for kernel's major data structures

### DIFF
--- a/aarch64_qemuvirt/src/main.rs
+++ b/aarch64_qemuvirt/src/main.rs
@@ -1,8 +1,5 @@
 #![no_std]
 #![no_main]
-// #![feature(custom_test_frameworks)]
-// #![test_runner(crate::kernel_tests::runner)]
-// #![reexport_test_harness_main = "ktests_launch"]
 
 #[cfg(not(target_arch = "aarch64"))]
 compile_error!("Must be compiled as aarch64");
@@ -10,8 +7,7 @@ compile_error!("Must be compiled as aarch64");
 use kernel::drivers::gicv2::GicV2;
 use kernel::drivers::pl011::Pl011;
 use kernel::drivers::Console;
-
-use core::arch::asm;
+use kernel::paging::PagingImpl;
 
 use cortex_a::asm;
 
@@ -21,14 +17,10 @@ const DTB_ADDR: usize = 0x4000_0000;
 extern "C" fn k_main(_device_tree_ptr: usize) -> ! {
     kernel::arch::aarch64::Aarch64::disable_fp_trap();
 
-    kernel::kernel_console::init(Pl011::new(0x0900_0000));
-    kernel::kprintln!("hello!");
+    static PL011: Pl011 = Pl011::new(0x0900_0000);
+    kernel::globals::set_console(&PL011);
 
-    #[cfg(test)]
-    {
-        kernel_tests::init(DTB_ADDR);
-        ktests_launch();
-    }
+    kernel::kprintln!("hello, I am GoOSe!");
 
     let mut gic = GicV2::new(0x8000000, 0x8010000);
     gic.enable(30); // Physical timer
@@ -44,33 +36,28 @@ extern "C" fn k_main(_device_tree_ptr: usize) -> ! {
         asm::barrier::dsb(asm::barrier::SY);
     };
 
-    let device_tree_ptr = DTB_ADDR;
-    let device_tree = kernel::device_tree::DeviceTree::new(device_tree_ptr);
-    //
-    let pmm = kernel::mm::PhysicalMemoryManager::from_device_tree(&device_tree, 4096);
-    let mut mm = kernel::mm::MemoryManager::new(pmm);
-    let pagetable = kernel::mm::map_address_space(
-        &device_tree,
-        &mut mm,
-        &[kernel::kernel_console::get_console()],
+    let device_tree = kernel::device_tree::DeviceTree::new(DTB_ADDR);
+
+    kernel::globals::PHYSICAL_MEMORY_MANAGER
+        .lock(|pmm| pmm.init_from_device_tree(&device_tree, 4096));
+    kernel::mm::map_address_space(&device_tree, &[&PL011]);
+
+    kernel::kprintln!("PMM has been initialized with the device tree... check");
+    kernel::kprintln!(
+        "kernel's address space has been mapped into the kernel's pagetable... check"
     );
-    mm.set_kernel_pagetable(pagetable);
+    kernel::kprintln!("Kernel initialization should be about done.");
 
-    // ???:
-    // why do we pass the pagetable after into the mm ?
-    //     (can we pass it at initialization)
-    // - also when we map, we reload the page table, enabling the MMU (SCTLR_EL1.M)
-    //   shouldn't that be separate ? ie map just put it in the pagetable, then we can manually reload it / enable paging ?
-
-    kernel::kprintln!("Kernel has been initialized");
-
-    mm.kernel_map(
-        0x0900_0000,
-        0x0450_0000,
-        kernel::mm::Permissions::READ | kernel::mm::Permissions::WRITE,
-    );
-    let mut uart = Pl011::new(0x0450_0000);
-    uart.write("Uart remaped");
+    kernel::kprintln!("Testing the remapping capabilities of our pagetable...");
+    kernel::globals::KERNEL_PAGETABLE.lock(|pagetable| {
+        pagetable.map(
+            0x0900_0000.into(),
+            0x0450_0000.into(),
+            kernel::mm::Permissions::READ | kernel::mm::Permissions::WRITE,
+        );
+    });
+    let uart = Pl011::new(0x0450_0000);
+    uart.write("Uart remaped, if you see this, it works !!!");
 
     loop {}
 }

--- a/drivers/src/init_cell.rs
+++ b/drivers/src/init_cell.rs
@@ -1,0 +1,25 @@
+use core::cell::UnsafeCell;
+
+pub struct InitCell<T: Sized> {
+    data: UnsafeCell<T>,
+}
+
+impl<T> InitCell<T> {
+    pub const fn new(data: T) -> Self {
+        Self {
+            data: UnsafeCell::new(data),
+        }
+    }
+
+    pub fn set<'a>(&'a self, f: impl FnOnce(&'a mut T)) {
+        let data = unsafe { &mut *self.data.get() };
+        f(data)
+    }
+
+    pub fn get(&self) -> &T {
+        unsafe { &*self.data.get() }
+    }
+}
+
+unsafe impl<T: Send> Send for InitCell<T> {}
+unsafe impl<T: Send> Sync for InitCell<T> {}

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -2,7 +2,11 @@
 
 #![no_std]
 
+pub mod init_cell;
+mod lock;
+
 pub mod ns16550;
+pub mod null_uart;
 pub mod pl011;
 pub mod qemuexit;
 
@@ -15,6 +19,6 @@ pub trait Driver {
     fn get_address_range(&self) -> Option<(usize, usize)>;
 }
 
-pub trait Console {
-    fn write(&mut self, data: &str);
+pub trait Console: Driver {
+    fn write(&self, data: &str);
 }

--- a/drivers/src/lock.rs
+++ b/drivers/src/lock.rs
@@ -1,0 +1,23 @@
+use core::cell::UnsafeCell;
+
+pub struct Lock<T: Sized> {
+    data: UnsafeCell<T>,
+}
+
+impl<T> Lock<T> {
+    pub const fn new(data: T) -> Self {
+        Self {
+            data: UnsafeCell::new(data),
+        }
+    }
+
+    pub fn lock<'a, R>(&'a self, f: impl FnOnce(&'a mut T) -> R) -> R {
+        // TODO: actually lock something...
+        let data = unsafe { &mut *self.data.get() };
+
+        f(data)
+    }
+}
+
+unsafe impl<T> Send for Lock<T> where T: Sized + Send {}
+unsafe impl<T> Sync for Lock<T> where T: Sized + Send {}

--- a/drivers/src/null_uart.rs
+++ b/drivers/src/null_uart.rs
@@ -1,0 +1,22 @@
+use super::{Console, Driver};
+
+#[derive(Debug)]
+pub struct NullUart;
+
+impl NullUart {
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Console for NullUart {
+    fn write(&self, _data: &str) {
+        // Does nothing, just a placeholder while a real uart is not in place.
+    }
+}
+
+impl Driver for NullUart {
+    fn get_address_range(&self) -> Option<(usize, usize)> {
+        None
+    }
+}

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 [dependencies]
 cfg-if = "1.0"
 static_assertions = "1.1.0"
+once_cell = { version = "1.16.0", default-features = false }
 modular-bitfield = "0.11"
 bitflags = "1.3"
 fdt = "0.1"

--- a/kernel/src/arch/aarch64/pgt48.rs
+++ b/kernel/src/arch/aarch64/pgt48.rs
@@ -1,3 +1,5 @@
+use crate::globals;
+use crate::kprintln;
 use crate::mm;
 use crate::paging;
 use crate::paging::Error;
@@ -198,14 +200,33 @@ union PageTableContent {
     entry: core::mem::ManuallyDrop<TableEntry>,
 }
 
+impl PageTableContent {
+    /// With Aarch64 Pgt48OA, if the first two bits are set to 0b00, entry/descriptor is invalid.
+    const fn new_invalid() -> Self {
+        unsafe { core::mem::transmute::<u64, Self>(0b00u64) }
+    }
+}
+
+#[repr(align(0x1000))]
 pub struct PageTable {
     entries: [PageTableContent; 512],
 }
 
 impl PageTable {
+    pub const fn zeroed() -> Self {
+        #[allow(clippy::uninit_assumed_init)]
+        let mut entries: [PageTableContent; 512] =
+            unsafe { core::mem::MaybeUninit::uninit().assume_init() };
+        let mut i = 0;
+        while i < 512 {
+            entries[i] = PageTableContent::new_invalid();
+            i += 1;
+        }
+        Self { entries }
+    }
+
     fn map_inner(
         &mut self,
-        mut mm: Option<&mut mm::MemoryManager>,
         paddr: PAddr,
         vaddr: VAddr,
         perms: mm::Permissions,
@@ -229,13 +250,8 @@ impl PageTable {
 
             let descriptor = unsafe { &mut content.descriptor };
             if descriptor.is_invalid() {
-                if let Some(mm) = mm.as_mut() {
-                    let new_page_table = PageTable::new(mm);
-
-                    descriptor.set_next_level(new_page_table);
-                } else {
-                    return Err(paging::Error::CannotMapNoAlloc);
-                }
+                let new_page_table = PageTable::new();
+                descriptor.set_next_level(new_page_table);
             }
 
             pagetable = descriptor.get_next_level();
@@ -246,9 +262,9 @@ impl PageTable {
 }
 
 impl PagingImpl for PageTable {
-    fn new<'alloc>(mm: &mut mm::MemoryManager) -> &'alloc mut Self {
+    fn new() -> &'static mut Self {
         // FIXME: No unwrap here
-        let page = mm.alloc_pages(1).unwrap();
+        let page = globals::PHYSICAL_MEMORY_MANAGER.lock(|pmm| pmm.alloc_rw_pages(1).unwrap());
         let page_table: *mut PageTable = page.into();
         // FIXME: Do not unwrap either
         let page_table = unsafe { page_table.as_mut().unwrap() };
@@ -265,36 +281,14 @@ impl PagingImpl for PageTable {
         4096
     }
 
-    fn map(
-        &mut self,
-        mm: &mut mm::MemoryManager,
-        pa: mm::PAddr,
-        va: mm::VAddr,
-        perms: mm::Permissions,
-    ) -> Result<(), Error> {
-        self.map_inner(Some(mm), pa.into(), va.into(), perms)?;
+    fn map(&mut self, pa: mm::PAddr, va: mm::VAddr, perms: mm::Permissions) -> Result<(), Error> {
+        self.map_inner(pa.into(), va.into(), perms)?;
 
         Ok(())
     }
 
-    fn map_noalloc(
-        &mut self,
-        pa: mm::PAddr,
-        va: mm::VAddr,
-        perms: mm::Permissions,
-    ) -> Result<(), paging::Error> {
-        self.map_inner(None, pa.into(), va.into(), perms)?;
-
-        Ok(())
-    }
-
-    fn add_invalid_entry(
-        &mut self,
-        mm: &mut mm::MemoryManager,
-        vaddr: mm::VAddr,
-    ) -> Result<(), Error> {
+    fn add_invalid_entry(&mut self, vaddr: mm::VAddr) -> Result<(), Error> {
         let entry = self.map_inner(
-            Some(mm),
             PAddr(0x0A0A_0A0A_0A0A_0A0A),
             vaddr.into(),
             mm::Permissions::READ,

--- a/kernel/src/device_tree.rs
+++ b/kernel/src/device_tree.rs
@@ -36,7 +36,7 @@ impl DeviceTree {
         mut f: F,
     ) {
         match self.dtb.find_node("/reserved-memory") {
-            None => return,
+            None => (),
             Some(reserved_memory) => {
                 let mut regions = reserved_memory
                     .children()

--- a/kernel/src/globals.rs
+++ b/kernel/src/globals.rs
@@ -1,0 +1,35 @@
+use crate::lock::Lock;
+
+use crate::mm;
+
+use drivers::init_cell::InitCell;
+use drivers::Console;
+
+static NULL_CONSOLE: drivers::null_uart::NullUart = drivers::null_uart::NullUart::new();
+
+pub static CONSOLE: InitCell<&'static (dyn drivers::Console + Sync)> = InitCell::new(&NULL_CONSOLE);
+pub static PHYSICAL_MEMORY_MANAGER: Lock<mm::PhysicalMemoryManager> =
+    Lock::new(mm::PhysicalMemoryManager::new());
+
+pub static KERNEL_PAGETABLE: Lock<crate::PagingImpl> = Lock::new(crate::PagingImpl::zeroed());
+
+pub enum KernelState {
+    EarlyInit,
+    MmuEnabledInit,
+}
+
+impl KernelState {
+    pub fn is_mmu_enabled(&self) -> bool {
+        matches!(self, Self::MmuEnabledInit)
+    }
+}
+
+pub static mut STATE: KernelState = KernelState::EarlyInit;
+
+pub fn set_console(new_console: &'static (dyn drivers::Console + Sync)) {
+    CONSOLE.set(|console| *console = new_console);
+}
+
+pub fn get_console() -> &'static dyn drivers::Console {
+    *CONSOLE.get()
+}

--- a/kernel/src/kernel_console.rs
+++ b/kernel/src/kernel_console.rs
@@ -1,26 +1,11 @@
 use core::fmt::{self, Write};
 
+use crate::globals;
+
 use drivers::Console;
-use drivers::Driver;
-
-pub static mut STDOUT_UART: Option<crate::ConsoleImpl> = None;
-
-pub fn init(uart: crate::ConsoleImpl) {
-    unsafe { STDOUT_UART = Some(uart) };
-}
-
-pub fn get_console() -> &'static dyn Driver {
-    if let Some(console) = unsafe { &STDOUT_UART } {
-        return console;
-    }
-
-    panic!("Cannot get address range of uninitialized console");
-}
 
 fn write(data: &str) {
-    if let Some(console) = unsafe { &mut STDOUT_UART } {
-        console.write(data);
-    }
+    globals::get_console().write(data);
 }
 
 struct KernelConsoleWriter;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,10 +1,18 @@
 #![no_std]
 #![feature(naked_functions)]
 #![feature(fn_align)]
+#![feature(const_mut_refs)]
+#![feature(slice_ptr_get)]
+#![feature(const_ptr_as_ref)]
+#![feature(const_slice_from_raw_parts_mut)]
+#![feature(iterator_try_collect)]
+#![feature(const_for)]
 
 pub mod arch;
 pub mod device_tree;
+pub mod globals;
 pub mod kernel_console;
+mod lock;
 pub mod mm;
 pub mod paging;
 mod utils;
@@ -31,3 +39,4 @@ cfg_if::cfg_if! {
 static_assertions::assert_impl_all!(ArchImpl: arch::Architecture);
 static_assertions::assert_impl_all!(InterruptsImpl: arch::ArchitectureInterrupts);
 static_assertions::assert_impl_all!(PagingImpl: paging::PagingImpl);
+static_assertions::assert_impl_all!(ConsoleImpl: drivers::Console);

--- a/kernel/src/lock.rs
+++ b/kernel/src/lock.rs
@@ -1,0 +1,23 @@
+use core::cell::UnsafeCell;
+
+pub struct Lock<T: Sized> {
+    data: UnsafeCell<T>,
+}
+
+impl<T> Lock<T> {
+    pub const fn new(data: T) -> Self {
+        Self {
+            data: UnsafeCell::new(data),
+        }
+    }
+
+    pub fn lock<'a, R>(&'a self, f: impl FnOnce(&'a mut T) -> R) -> R {
+        // TODO: actually lock something...
+        let data = unsafe { &mut *self.data.get() };
+
+        f(data)
+    }
+}
+
+unsafe impl<T> Send for Lock<T> where T: Sized + Send {}
+unsafe impl<T> Sync for Lock<T> where T: Sized + Send {}

--- a/kernel/src/paging.rs
+++ b/kernel/src/paging.rs
@@ -14,7 +14,7 @@ impl From<TryFromIntError> for Error {
 }
 
 pub trait PagingImpl {
-    fn new<'alloc>(mm: &mut mm::MemoryManager) -> &'alloc mut Self;
+    fn new() -> &'static mut Self;
 
     fn get_page_size() -> usize;
 
@@ -30,26 +30,9 @@ pub trait PagingImpl {
         ((addr + page_size - 1) / page_size) * page_size
     }
 
-    fn map(
-        &mut self,
-        mm: &mut mm::MemoryManager,
-        pa: mm::PAddr,
-        va: mm::VAddr,
-        perms: mm::Permissions,
-    ) -> Result<(), Error>;
+    fn map(&mut self, pa: mm::PAddr, va: mm::VAddr, perms: mm::Permissions) -> Result<(), Error>;
 
-    fn map_noalloc(
-        &mut self,
-        pa: mm::PAddr,
-        va: mm::VAddr,
-        perms: mm::Permissions,
-    ) -> Result<(), Error>;
-
-    fn add_invalid_entry(
-        &mut self,
-        mm: &mut mm::MemoryManager,
-        vaddr: mm::VAddr,
-    ) -> Result<(), Error>;
+    fn add_invalid_entry(&mut self, vaddr: mm::VAddr) -> Result<(), Error>;
 
     fn reload(&mut self);
     fn disable(&mut self);
@@ -62,7 +45,7 @@ mod tests {
 
     struct PagingImplDummy {}
     impl PagingImpl for PagingImplDummy {
-        fn new<'alloc>(_mm: &mut mm::MemoryManager) -> &'alloc mut Self {
+        fn new<'alloc>() -> &'alloc mut Self {
             unreachable!("We will never use this, we just need the compiler to be happy");
         }
 
@@ -71,16 +54,6 @@ mod tests {
         }
 
         fn map(
-            &mut self,
-            _mm: &mut mm::MemoryManager,
-            _pa: mm::PAddr,
-            _va: mm::VAddr,
-            _perms: mm::Permissions,
-        ) -> Result<(), Error> {
-            unreachable!("We will never use this, we just need the compiler to be happy");
-        }
-
-        fn map_noalloc(
             &mut self,
             _pa: mm::PAddr,
             _va: mm::VAddr,


### PR DESCRIPTION
Previously everything was passed as arguments.
It made the kernel very unwieldy, lifetimes were horrible to manage etc... and we weren't even thread-safe.
Now, "major data structures" (console, kernel's pagetable, pmm) are stored in globals, with all the tread-safety goodness infrastructure.