### PR TITLE
misc: Swap staticvec with arrayvec

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -16,12 +19,15 @@
       }
     },
     "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -32,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671525405,
-        "narHash": "sha256-MEgNxm/oRt5w4ycMENewfZQKOak0ixmjVPfXM96N1FA=",
+        "lastModified": 1684280442,
+        "narHash": "sha256-nC1/kfh6tpMQSLQalbNTNnireIlxvLLugrjZdasNh+I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cbe419ed4c8f98bd82d169c321d339ea30904f1f",
+        "rev": "6c591e7adc514090a77209f56c9d0c551ab8530d",
         "type": "github"
       },
       "original": {
@@ -48,11 +54,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1665296151,
-        "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
+        "lastModified": 1681358109,
+        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "14ccaaedd95a488dd7ae142757884d8e125b3363",
+        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
         "type": "github"
       },
       "original": {
@@ -75,16 +81,46 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1671589280,
-        "narHash": "sha256-FmJ4SC+Ewi1iMhdtRcrwirMfvW7h2jakT7ILLo9BVws=",
+        "lastModified": 1684376381,
+        "narHash": "sha256-XVFTXADfvBXKwo4boqfg80awUbT+JgQvlQ8uZ+Xgo1s=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "bfc54bcf98dacdc649c88a82bf14d00b399aa3bb",
+        "rev": "7c9a265c2eaa5783bc18593b1aec39a85653c076",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -17,7 +17,7 @@ spin = "0.9"
 goblin = { version = "0.6", default-features = false, features = ["elf64"] }
 qemu-exit = "3.0"
 hal_core = { path = "../hal_core" }
-staticvec = { version = "0.11.9", default-features = false }
+arrayvec = { version = "0.7", default-features = false }
 tests = { path = "../tests", artifact = "bin" }
 align-data = "0.1"
 

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -13,8 +13,8 @@ use hal_core::mm::{PageMap, Permissions, VAddr};
 use crate::drivers;
 use drivers::Driver;
 
+use arrayvec::ArrayVec;
 use core::{iter, slice};
-use staticvec::StaticVec;
 
 extern "C" {
     pub static KERNEL_START: usize;
@@ -103,10 +103,10 @@ pub fn alloc_pages_for_hal(count: usize) -> hal_core::mm::PAddr {
 }
 
 pub fn map_address_space(device_tree: &DeviceTree, drivers: &[&dyn Driver]) -> Result<(), Error> {
-    let mut r_entries = StaticVec::<(usize, usize), 128>::new();
-    let mut rw_entries = StaticVec::<(usize, usize), 128>::new();
-    let mut rwx_entries = StaticVec::<(usize, usize), 128>::new();
-    let mut pre_allocated_entries = StaticVec::<(usize, usize), 1024>::new();
+    let mut r_entries = ArrayVec::<(usize, usize), 128>::new();
+    let mut rw_entries = ArrayVec::<(usize, usize), 128>::new();
+    let mut rwx_entries = ArrayVec::<(usize, usize), 128>::new();
+    let mut pre_allocated_entries = ArrayVec::<(usize, usize), 1024>::new();
 
     // Add entries/descriptors in the pagetable for all of accessible memory regions.
     // That way in the future, mapping those entries won't require any memory allocations,


### PR DESCRIPTION
Staticvec is not compiling with latest nightly. As we do not really
need "static" vectors but just some kind of vectors, let's just use
arrayvec which initialize static size vectors on the stack. A bonus side
effect is that this vectors will reside on the stack instead of some
segment and thus be released after the address space is mapped.

Signed-off-by: Esteban Blanc <estblcsk@gmail.com>
