### PR TITLE
Refactor console with logging

### DIFF
--- a/aarch64_qemuvirt/Cargo.toml
+++ b/aarch64_qemuvirt/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 kernel = { path = "../kernel", features = ["aarch64_pgt48oa"] }
 cortex-a = "8.1"
 tock-registers = "0.7.0"
+log = "0.4"

--- a/aarch64_qemuvirt/src/main.rs
+++ b/aarch64_qemuvirt/src/main.rs
@@ -15,7 +15,7 @@ extern "C" fn k_main(_device_tree_ptr: usize) -> ! {
     kernel::hal::cpu::disable_fp_trapping();
 
     static PL011: Pl011 = Pl011::new(0x0900_0000);
-    kernel::globals::set_earlyinit_console(&PL011);
+    kernel::kernel_console::set_earlyinit_console(&PL011);
 
     kernel::kprintln!("hello, I am a goOSe! proud member of the gagelen !!!");
 

--- a/aarch64_qemuvirt/src/main.rs
+++ b/aarch64_qemuvirt/src/main.rs
@@ -10,6 +10,8 @@ use kernel::drivers::pl011::Pl011;
 
 const DTB_ADDR: usize = 0x4000_0000;
 
+use log::info;
+
 #[no_mangle]
 extern "C" fn k_main(_device_tree_ptr: usize) -> ! {
     kernel::hal::cpu::disable_fp_trapping();
@@ -17,7 +19,9 @@ extern "C" fn k_main(_device_tree_ptr: usize) -> ! {
     static PL011: Pl011 = Pl011::new(0x0900_0000);
     kernel::kernel_console::set_earlyinit_console(&PL011);
 
-    kernel::kprintln!("hello, I am a goOSe! proud member of the gagelen !!!");
+    kernel::kernel_console::init_logging().unwrap();
+
+    info!("hello, I am a goOSe! proud member of the gagelen !!!");
 
     unsafe {
         kernel::hal::irq::init_el1_exception_handlers();

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -20,6 +20,7 @@ hal_core = { path = "../hal_core" }
 arrayvec = { version = "0.7", default-features = false }
 tests = { path = "../tests", artifact = "bin" }
 align-data = "0.1"
+delog = "0.1.6"
 
 [dev-dependencies]
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -20,7 +20,7 @@ hal_core = { path = "../hal_core" }
 arrayvec = { version = "0.7", default-features = false }
 tests = { path = "../tests", artifact = "bin" }
 align-data = "0.1"
-delog = "0.1.6"
+log = "0.4"
 
 [dev-dependencies]
 

--- a/kernel/src/driver_manager.rs
+++ b/kernel/src/driver_manager.rs
@@ -3,7 +3,7 @@ use alloc::{boxed::Box, collections::LinkedList, sync::Arc};
 use super::device_tree::DeviceTree;
 use super::drivers::{self, Matcher};
 use super::error::Error;
-use super::globals;
+use super::kernel_console;
 use drivers::{Console, Driver};
 use fdt::node::FdtNode;
 
@@ -80,7 +80,7 @@ impl DriverManager {
     fn register_console(&mut self, cons: Box<dyn Console + Sync + Send>) -> Result<(), Error> {
         let cons: Arc<dyn Console + Sync + Send> = Arc::from(cons);
         self.register_driver(cons.clone());
-        globals::CONSOLE.set(cons.clone())?;
+        kernel_console::set_console(cons.clone())?;
 
         Ok(())
     }

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -11,6 +11,7 @@ pub enum Error {
     InitOnce(init_once::Error),
     Allocator(mm::AllocatorError),
     Hal(hal_core::Error),
+    SetLoggerError(log::SetLoggerError),
 }
 
 impl From<init_once::Error> for Error {
@@ -34,5 +35,11 @@ impl From<mm::AllocatorError> for Error {
 impl From<hal_core::Error> for Error {
     fn from(e: hal_core::Error) -> Self {
         Self::Hal(e)
+    }
+}
+
+impl From<log::SetLoggerError> for Error {
+    fn from(e: log::SetLoggerError) -> Self {
+        Self::SetLoggerError(e)
     }
 }

--- a/kernel/src/globals.rs
+++ b/kernel/src/globals.rs
@@ -9,11 +9,6 @@ use utils::init_once::InitOnce;
 
 use alloc::sync::Arc;
 
-static NULL_CONSOLE: drivers::null_uart::NullUart = drivers::null_uart::NullUart::new();
-
-pub static EARLYINIT_CONSOLE: InitCell<&'static (dyn drivers::Console + Sync)> =
-    InitCell::new(&NULL_CONSOLE);
-pub static CONSOLE: InitOnce<Arc<dyn drivers::Console + Sync + Send>> = InitOnce::new();
 pub static PHYSICAL_MEMORY_MANAGER: Lock<mm::PhysicalMemoryManager> =
     Lock::new(mm::PhysicalMemoryManager::new());
 
@@ -33,11 +28,3 @@ impl KernelState {
 }
 
 pub static mut STATE: KernelState = KernelState::EarlyInit;
-
-pub fn set_earlyinit_console(new_console: &'static (dyn drivers::Console + Sync)) {
-    EARLYINIT_CONSOLE.set(|console| *console = new_console);
-}
-
-pub fn get_earlyinit_console() -> &'static dyn drivers::Console {
-    *EARLYINIT_CONSOLE.get()
-}

--- a/kernel/src/kernel_console.rs
+++ b/kernel/src/kernel_console.rs
@@ -2,7 +2,6 @@ use core::fmt::{self, Write};
 
 use crate::drivers::Console;
 use crate::Error;
-use crate::hal;
 
 use alloc::sync::Arc;
 
@@ -78,19 +77,6 @@ pub fn set_console(new_console: Arc<dyn Console + Sync + Send>) -> Result<(), Er
 
     // TODO: return an error if the error already was some (unless we consider it is ok)
     Ok(())
-}
-
-#[panic_handler]
-#[cfg(not(test))]
-fn panic(info: &core::panic::PanicInfo) -> ! {
-    error!("\x1b[31mkernel panic\x1b[0m: {}", info);
-
-    error!("hal panic info: {:X?}", hal::panic_info());
-
-    loop {
-        use core::arch::asm;
-        unsafe { asm!("wfi") }
-    }
 }
 
 #[macro_export]

--- a/kernel/src/kernel_console.rs
+++ b/kernel/src/kernel_console.rs
@@ -68,7 +68,7 @@ impl log::Log for KernelConsoleWriter {
 static KERNEL_CONSOLE_WRITER: KernelConsoleWriter = KernelConsoleWriter;
 
 pub fn init_logging() -> Result<(), Error> {
-    log::set_logger(&KERNEL_CONSOLE_WRITER);
+    log::set_logger(&KERNEL_CONSOLE_WRITER)?;
     log::set_max_level(LevelFilter::Trace);
 
     Ok(())
@@ -77,9 +77,9 @@ pub fn init_logging() -> Result<(), Error> {
 #[panic_handler]
 #[cfg(not(test))]
 fn panic(info: &core::panic::PanicInfo) -> ! {
-    crate::kprintln!("\x1b[31mkernel panic\x1b[0m: {}", info);
+    error!("\x1b[31mkernel panic\x1b[0m: {}", info);
 
-    crate::kprintln!("hal panic info: {:X?}", hal::panic_info());
+    error!("hal panic info: {:X?}", hal::panic_info());
 
     loop {
         use core::arch::asm;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -26,6 +26,7 @@ pub mod globals;
 pub mod kernel_console;
 mod lock;
 pub mod mm;
+mod panic;
 
 // TODO: redo the unit tests with Mockall
 // pub mod kernel_tests;

--- a/kernel/src/mm/binary_buddy_allocator.rs
+++ b/kernel/src/mm/binary_buddy_allocator.rs
@@ -2,6 +2,8 @@ use crate::globals;
 
 use core::alloc::{GlobalAlloc, Layout};
 
+use log::warn;
+
 pub struct BinaryBuddyAllocator;
 
 unsafe impl Sync for BinaryBuddyAllocator {}
@@ -31,7 +33,7 @@ unsafe impl GlobalAlloc for BinaryBuddyAllocator {
     }
 
     unsafe fn dealloc(&self, _: *mut u8, _: Layout) {
-        crate::kprintln!("[WARNING] dealloc is not implemented yet, freeing memory isn't supported by the allocator");
+        warn!("[WARNING] dealloc is not implemented yet, freeing memory isn't supported by the allocator");
     }
 }
 

--- a/kernel/src/mm/mod.rs
+++ b/kernel/src/mm/mod.rs
@@ -16,6 +16,8 @@ use drivers::Driver;
 use arrayvec::ArrayVec;
 use core::{iter, slice};
 
+use log::debug;
+
 extern "C" {
     pub static KERNEL_START: usize;
     pub static KERNEL_END: usize;
@@ -153,10 +155,10 @@ pub fn map_address_space<'a, I: Iterator<Item = &'a &'a dyn Driver>>(
         //      for now just crammed all memory regions as rw_entries a bit higher in the function.
     });
 
-    crate::kprintln!("r_entries: {:X?}", r_entries);
-    crate::kprintln!("rw_entries: {:X?}", rw_entries);
-    crate::kprintln!("rwx_entries: {:X?}", rwx_entries);
-    crate::kprintln!("pre_allocated_entries: {:X?}", pre_allocated_entries);
+    debug!("r_entries: {:X?}", r_entries);
+    debug!("rw_entries: {:X?}", rw_entries);
+    debug!("rwx_entries: {:X?}", rwx_entries);
+    debug!("pre_allocated_entries: {:X?}", pre_allocated_entries);
 
     hal::mm::init_paging(
         r_entries.into_iter(),

--- a/kernel/src/mm/physical_memory_manager.rs
+++ b/kernel/src/mm/physical_memory_manager.rs
@@ -6,6 +6,8 @@ use crate::Error;
 use core::mem;
 use hal_core::mm::{PageMap, Permissions, VAddr};
 
+use log::debug;
+
 /// A range similar to core::ops::Range but that is copyable.
 /// The range is half-open, inclusive below, exclusive above, ie. [start; end[
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -256,7 +258,7 @@ impl PhysicalMemoryManager {
         );
 
         for (i, reg) in available_regions.iter().flatten().enumerate() {
-            crate::kprintln!("region {}: {:X?}", i, reg);
+            debug!("region {}: {:X?}", i, reg);
         }
 
         let page_count = Self::count_pages(&available_regions, page_size);

--- a/kernel/src/panic.rs
+++ b/kernel/src/panic.rs
@@ -1,0 +1,15 @@
+use crate::hal;
+use core::arch::asm;
+use log::error;
+
+#[panic_handler]
+#[cfg(not(test))]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    error!("\x1b[31mkernel panic\x1b[0m: {}", info);
+
+    error!("hal panic info: {:X?}", hal::panic_info());
+
+    loop {
+        unsafe { asm!("wfi") }
+    }
+}

--- a/riscv64_qemuvirt/Cargo.toml
+++ b/riscv64_qemuvirt/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 kernel = { path = "../kernel", features = ["riscv64_sv39"] }
 align-data = "0.1.0"
+log = "0.4"

--- a/riscv64_qemuvirt/src/main.rs
+++ b/riscv64_qemuvirt/src/main.rs
@@ -15,6 +15,8 @@ use kernel::executable::elf::Elf;
 
 use align_data::{include_aligned, Align4K};
 
+use log::info;
+
 pub const UART_ADDR: usize = 0x1000_0000;
 pub const UART_INTERRUPT_NUMBER: u16 = 10;
 
@@ -23,7 +25,9 @@ extern "C" fn k_main(_core_id: usize, device_tree_ptr: usize) -> ! {
     static NS16550: Ns16550 = Ns16550::new(UART_ADDR);
     kernel::kernel_console::set_earlyinit_console(&NS16550);
 
-    kernel::kprintln!("GoOSe is booting");
+    kernel::kernel_console::init_logging().unwrap();
+
+    info!("GoOSe is booting");
 
     // #[cfg(test)]
     // {

--- a/riscv64_qemuvirt/src/main.rs
+++ b/riscv64_qemuvirt/src/main.rs
@@ -21,7 +21,7 @@ pub const UART_INTERRUPT_NUMBER: u16 = 10;
 #[no_mangle]
 extern "C" fn k_main(_core_id: usize, device_tree_ptr: usize) -> ! {
     static NS16550: Ns16550 = Ns16550::new(UART_ADDR);
-    kernel::globals::set_earlyinit_console(&NS16550);
+    kernel::kernel_console::set_earlyinit_console(&NS16550);
 
     kernel::kprintln!("GoOSe is booting");
 


### PR DESCRIPTION
refactor(console): move panic_handler to its file

refactor(kernel_console): reduce globals

Previous code was a bit complicated, jumping all over the place.
New code has two parts:
  - KERNEL_CONSOLE
    the part taking care of printing out, to which console it should
    write....
    Also it is hidden behind a mutex, so we don't need Sync on the
    Consoles (to be done).
  - KERNEL_LOGGER
    The log trait requires `&self` whereas fmt::Write needs an `&mut
    self`, so I just put two types to avoid any issues.

replace all kprint(ln)?! with log macros

feat(console): implement log for our console

refac(console): reduce globals scope

Rest of the code was interacting directly with globals.
Now there are hidden behind setters. And no need for getters since only
kernel_console.rs needs to get them.