### PR TITLE
In kernel tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install qemu
         run: sudo apt-get update && sudo apt-get install qemu-system-misc opensbi
 
-      - run: cd riscv64_qemuvirt && cargo run
+      - run: cd riscv64_qemuvirt && cargo run -F launch_tests
 
   test_aarch64:
     runs-on: ubuntu-latest
@@ -41,4 +41,4 @@ jobs:
       - name: Install qemu
         run: sudo apt-get update && sudo apt-get install qemu-system-arm
 
-      - run: cd aarch64_qemuvirt && cargo run
+      - run: cd aarch64_qemuvirt && cargo run -F launch_tests

--- a/aarch64_qemuvirt/Cargo.toml
+++ b/aarch64_qemuvirt/Cargo.toml
@@ -10,3 +10,6 @@ kernel = { path = "../kernel", features = ["aarch64_pgt48oa"] }
 cortex-a = "8.1"
 tock-registers = "0.7.0"
 log = "0.4"
+
+[features]
+launch_tests = []

--- a/aarch64_qemuvirt/src/main.rs
+++ b/aarch64_qemuvirt/src/main.rs
@@ -10,6 +10,8 @@ use kernel::drivers::pl011::Pl011;
 
 const DTB_ADDR: usize = 0x4000_0000;
 
+const LAUNCH_TESTS: bool = cfg!(feature = "launch_tests");
+
 use log::info;
 
 #[no_mangle]
@@ -34,7 +36,7 @@ extern "C" fn k_main(_device_tree_ptr: usize) -> ! {
 
     let device_tree = kernel::device_tree::DeviceTree::new(DTB_ADDR).unwrap();
 
-    kernel::generic_main::generic_main(device_tree, &[&PL011]);
+    kernel::generic_main::generic_main::<LAUNCH_TESTS>(device_tree, &[&PL011]);
 
     unreachable!();
 }

--- a/kernel/src/generic_main.rs
+++ b/kernel/src/generic_main.rs
@@ -20,7 +20,7 @@ use align_data::Align4K;
 
 use log::{info, trace};
 
-pub fn generic_main(dt: DeviceTree, hacky_devices: &[&dyn Driver]) -> ! {
+pub fn generic_main<const LAUNCH_TESTS: bool>(dt: DeviceTree, hacky_devices: &[&dyn Driver]) -> ! {
     info!("Entered generic_main");
     let qemu_exit = QemuExit::new();
     let qemu_exit_slice = [&qemu_exit as &dyn Driver];
@@ -40,15 +40,20 @@ pub fn generic_main(dt: DeviceTree, hacky_devices: &[&dyn Driver]) -> ! {
 
     hal::cpu::unmask_interrupts();
 
-    // Shit-tier testing
-    test_timer_interrupt();
-    #[cfg(target_arch = "aarch64")]
-    test_pagetable_remap();
-    test_elf_loader_basic();
+    if LAUNCH_TESTS {
+        info!("Launching tests...");
+        // Shit-tier testing
+        test_timer_interrupt();
+        #[cfg(target_arch = "aarch64")]
+        test_pagetable_remap();
+        test_elf_loader_basic();
 
-    info!("TESTS FINISHED SUCCESSFULY ✅");
+        info!("TESTS FINISHED SUCCESSFULY ✅");
 
-    qemu_exit.exit_success();
+        qemu_exit.exit_success();
+    } else {
+        panic!("no scheduler to launch yet...");
+    }
 }
 
 fn test_timer_interrupt() {

--- a/kernel/src/generic_main.rs
+++ b/kernel/src/generic_main.rs
@@ -62,7 +62,7 @@ fn test_timer_interrupt() {
             NUM_INTERRUPTS
         );
 
-        hal::irq::set_timer(50_000).expect("failed to set timer for test");
+        hal::cpu::clear_physical_timer();
 
         hal::irq::set_timer_handler(|| {
             trace!(".");
@@ -72,6 +72,8 @@ fn test_timer_interrupt() {
                     .expect("failed to set timer in the timer handler of the test");
             }
         });
+
+        hal::irq::set_timer(50_000).expect("failed to set timer for test");
 
         while CNT.load(Ordering::Relaxed) < NUM_INTERRUPTS {}
 

--- a/kernel/src/generic_main.rs
+++ b/kernel/src/generic_main.rs
@@ -1,24 +1,14 @@
 use super::device_tree::DeviceTree;
-use super::driver_manager::DriverManager;
 use super::drivers::qemuexit::QemuExit;
-use super::drivers::{
-    pl011::Pl011,
-    // gicv2::GicV2
-    Console,
-    Driver,
-};
+use super::drivers::Driver;
 use super::globals;
-use core::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::hal;
 use crate::mm::{alloc_pages_for_hal, map_address_space};
-use hal_core::mm::{PageMap, Permissions};
 
-use crate::executable::elf::Elf;
-use align_data::include_aligned;
-use align_data::Align4K;
+use crate::tests::{self, TestResult};
 
-use log::{info, trace};
+use log::info;
 
 pub fn generic_main<const LAUNCH_TESTS: bool>(dt: DeviceTree, hacky_devices: &[&dyn Driver]) -> ! {
     info!("Entered generic_main");
@@ -41,83 +31,11 @@ pub fn generic_main<const LAUNCH_TESTS: bool>(dt: DeviceTree, hacky_devices: &[&
     hal::cpu::unmask_interrupts();
 
     if LAUNCH_TESTS {
-        info!("Launching tests...");
-        // Shit-tier testing
-        test_timer_interrupt();
-        #[cfg(target_arch = "aarch64")]
-        test_pagetable_remap();
-        test_elf_loader_basic();
-
-        info!("TESTS FINISHED SUCCESSFULY ✅");
-
-        qemu_exit.exit_success();
+        match tests::launch() {
+            TestResult::Success => qemu_exit.exit_success(),
+            TestResult::Failure => qemu_exit.exit_failure(),
+        }
     } else {
         panic!("no scheduler to launch yet...");
     }
-}
-
-fn test_timer_interrupt() {
-    if true {
-        // IRQ
-        static CNT: AtomicUsize = AtomicUsize::new(0);
-        const NUM_INTERRUPTS: usize = 3;
-
-        info!(
-            "Testing timer interrupts, waiting for {} interrupts",
-            NUM_INTERRUPTS
-        );
-
-        hal::cpu::clear_physical_timer();
-
-        hal::irq::set_timer_handler(|| {
-            trace!(".");
-
-            if CNT.fetch_add(1, Ordering::Relaxed) < NUM_INTERRUPTS {
-                hal::irq::set_timer(50_000)
-                    .expect("failed to set timer in the timer handler of the test");
-            }
-        });
-
-        hal::irq::set_timer(50_000).expect("failed to set timer for test");
-
-        while CNT.load(Ordering::Relaxed) < NUM_INTERRUPTS {}
-
-        // TODO: restore the timer handler
-        hal::cpu::clear_physical_timer();
-        info!("test_timer_interrupts ✅");
-    } else {
-        // // Synchronous exception
-        // unsafe {
-        //     asm!("svc 42");
-        // }
-    }
-}
-
-fn test_pagetable_remap() {
-    info!("Testing the remapping capabilities of our pagetable...");
-    hal::mm::current()
-        .map(
-            hal_core::mm::VAddr::new(0x0450_0000),
-            hal_core::mm::PAddr::new(0x0900_0000),
-            Permissions::READ | Permissions::WRITE,
-            alloc_pages_for_hal,
-        )
-        .unwrap();
-    let uart = Pl011::new(0x0450_0000);
-    uart.write("Uart remaped, if you see this, it works !!!\n");
-    info!("test_pagetable_remap ✅");
-}
-
-fn test_elf_loader_basic() {
-    static TEST_BIN: &[u8] = include_aligned!(Align4K, env!("CARGO_BIN_FILE_TESTS"));
-
-    let test_bin = Elf::from_bytes(TEST_BIN);
-    info!("[OK] Elf from_bytes {}", env!("CARGO_BIN_FILE_TESTS"));
-    test_bin.load().unwrap();
-    info!("[OK] Elf loaded");
-    let entry_point: extern "C" fn() -> u8 =
-        unsafe { core::mem::transmute(test_bin.get_entry_point()) };
-    info!("[OK] Elf loaded, entry point is {:?}", entry_point);
-    entry_point();
-    info!("[OK] Returned for Elf");
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -27,6 +27,7 @@ pub mod kernel_console;
 mod lock;
 pub mod mm;
 mod panic;
+mod tests;
 
 // TODO: redo the unit tests with Mockall
 // pub mod kernel_tests;

--- a/kernel/src/tests.rs
+++ b/kernel/src/tests.rs
@@ -1,0 +1,128 @@
+use log::{debug, info, trace};
+
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use super::drivers::{pl011::Pl011, Console};
+use crate::executable::elf::Elf;
+use crate::hal;
+use crate::mm::alloc_pages_for_hal;
+use hal_core::mm::{PageMap, Permissions};
+
+use align_data::include_aligned;
+use align_data::Align4K;
+
+pub enum TestResult {
+    Success,
+    Failure,
+}
+
+struct Test {
+    name: &'static str,
+    test: fn() -> TestResult,
+}
+
+const TESTS: &[Test] = &[
+    Test {
+        name: "timer interrupts",
+        test: test_timer_interrupt,
+    },
+    #[cfg(target_arch = "aarch64")]
+    Test {
+        name: "pagetable does remap",
+        test: test_pagetable_remap,
+    },
+    Test {
+        name: "basic elf loader",
+        test: test_elf_loader_basic,
+    },
+];
+
+pub fn launch() -> TestResult {
+    let mut res = TestResult::Success;
+
+    info!("Launching tests...");
+    for (i, test) in TESTS.iter().enumerate() {
+        info!("Test #{} \'{}\':", i, test.name);
+        match (test.test)() {
+            TestResult::Failure => {
+                info!("#{} failed ❌", i);
+                res = TestResult::Failure;
+            }
+            TestResult::Success => {
+                info!("#{} passed ✅", i);
+            }
+        }
+    }
+
+    res
+}
+
+fn test_timer_interrupt() -> TestResult {
+    if true {
+        // IRQ
+        static CNT: AtomicUsize = AtomicUsize::new(0);
+        const NUM_INTERRUPTS: usize = 3;
+
+        debug!(
+            "Testing timer interrupts, waiting for {} interrupts",
+            NUM_INTERRUPTS
+        );
+
+        hal::cpu::clear_physical_timer();
+
+        hal::irq::set_timer_handler(|| {
+            trace!(".");
+
+            if CNT.fetch_add(1, Ordering::Relaxed) < NUM_INTERRUPTS {
+                hal::irq::set_timer(50_000)
+                    .expect("failed to set timer in the timer handler of the test");
+            }
+        });
+
+        hal::irq::set_timer(50_000).expect("failed to set timer for test");
+
+        while CNT.load(Ordering::Relaxed) < NUM_INTERRUPTS {}
+
+        // TODO: restore the timer handler
+        hal::cpu::clear_physical_timer();
+        TestResult::Success
+    } else {
+        // // Synchronous exception
+        // unsafe {
+        //     asm!("svc 42");
+        // }
+        TestResult::Failure
+    }
+}
+
+fn test_pagetable_remap() -> TestResult {
+    info!("Testing the remapping capabilities of our pagetable...");
+    hal::mm::current()
+        .map(
+            hal_core::mm::VAddr::new(0x0450_0000),
+            hal_core::mm::PAddr::new(0x0900_0000),
+            Permissions::READ | Permissions::WRITE,
+            alloc_pages_for_hal,
+        )
+        .unwrap();
+    let uart = Pl011::new(0x0450_0000);
+    uart.write("Uart remaped, if you see this, it works !!!\n");
+
+    TestResult::Success
+}
+
+fn test_elf_loader_basic() -> TestResult {
+    static TEST_BIN: &[u8] = include_aligned!(Align4K, env!("CARGO_BIN_FILE_TESTS"));
+
+    let test_bin = Elf::from_bytes(TEST_BIN);
+    debug!("[OK] Elf from_bytes {}", env!("CARGO_BIN_FILE_TESTS"));
+    test_bin.load().unwrap();
+    debug!("[OK] Elf loaded");
+    let entry_point: extern "C" fn() -> u8 =
+        unsafe { core::mem::transmute(test_bin.get_entry_point()) };
+    debug!("[OK] Elf loaded, entry point is {:?}", entry_point);
+    entry_point();
+    debug!("[OK] Returned for Elf");
+
+    TestResult::Success
+}

--- a/riscv64_qemuvirt/Cargo.toml
+++ b/riscv64_qemuvirt/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2021"
 kernel = { path = "../kernel", features = ["riscv64_sv39"] }
 align-data = "0.1.0"
 log = "0.4"
+
+[features]
+launch_tests = []

--- a/riscv64_qemuvirt/src/main.rs
+++ b/riscv64_qemuvirt/src/main.rs
@@ -20,6 +20,8 @@ use log::info;
 pub const UART_ADDR: usize = 0x1000_0000;
 pub const UART_INTERRUPT_NUMBER: u16 = 10;
 
+const LAUNCH_TESTS: bool = cfg!(feature = "launch_tests");
+
 #[no_mangle]
 extern "C" fn k_main(_core_id: usize, device_tree_ptr: usize) -> ! {
     static NS16550: Ns16550 = Ns16550::new(UART_ADDR);
@@ -40,7 +42,7 @@ extern "C" fn k_main(_core_id: usize, device_tree_ptr: usize) -> ! {
     }
 
     let device_tree = kernel::device_tree::DeviceTree::new(device_tree_ptr).unwrap();
-    kernel::generic_main::generic_main(device_tree, &[&NS16550]);
+    kernel::generic_main::generic_main::<LAUNCH_TESTS>(device_tree, &[&NS16550]);
 
     unreachable!();
 }


### PR DESCRIPTION
- fix(test_timer_interrupts): remove race condition
- add feature to compile for launching tests
    
    Previously we were always launching the in-kernel tests.
    Add a feature gates so that you don't launch tests by default.
    
    For example, run the tests on aarch64 with the folliwng:
    ```
    cd aarch64_qemuvirt; cargo run -F launch_tests
    ```
    
    Additionaly, with this we can compile the tests to run on embedded
    platforms easily.
- organize in-kernel tests into into their own module