### PR TITLE
refactor(AddressRange): create and use a proper type

### DIFF
--- a/hal_aarch64/src/mm/mod.rs
+++ b/hal_aarch64/src/mm/mod.rs
@@ -1,6 +1,6 @@
 use hal_core::{
-    mm::{PageAllocFn, PageMap},
-    Error, Range,
+    mm::{self, PageAllocFn, PageMap},
+    AddressRange, Error,
 };
 
 use cortex_a::asm::barrier;
@@ -24,10 +24,10 @@ pub fn current() -> &'static mut PageTable {
 }
 
 pub fn init_paging(
-    r: impl Iterator<Item = Range>,
-    rw: impl Iterator<Item = Range>,
-    rwx: impl Iterator<Item = Range>,
-    pre_allocated: impl Iterator<Item = Range>,
+    r: impl Iterator<Item = AddressRange>,
+    rw: impl Iterator<Item = AddressRange>,
+    rwx: impl Iterator<Item = AddressRange>,
+    pre_allocated: impl Iterator<Item = AddressRange>,
     alloc: PageAllocFn,
 ) -> Result<(), Error> {
     hal_core::mm::init_paging::<PageTable>(r, rw, rwx, pre_allocated, alloc, |pt| {
@@ -72,4 +72,8 @@ unsafe fn load_pagetable(pt: &'static mut PageTable) {
     SCTLR_EL1.modify(SCTLR_EL1::M::Enable);
 
     barrier::isb(barrier::SY);
+}
+
+pub fn align_up(addr: usize) -> usize {
+    mm::align_up(addr, PageTable::PAGE_SIZE)
 }

--- a/hal_core/Cargo.toml
+++ b/hal_core/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 bitflags = "2.3"
+log = "0.4"

--- a/hal_core/src/lib.rs
+++ b/hal_core/src/lib.rs
@@ -1,5 +1,8 @@
 #![no_std]
 
+use core::convert::Into;
+use core::ops::Range;
+
 pub mod mm;
 
 #[derive(Debug)]
@@ -7,27 +10,51 @@ pub enum Error {}
 
 pub type TimerCallbackFn = fn();
 
-pub type Range = (usize, usize);
-// /// A range similar to core::ops::Range but that is copyable.
-// /// The range is half-open, inclusive below, exclusive above, ie. [start; end[
-// #[derive(Debug, Copy, Clone, PartialEq)]
-// pub struct Range<T: Copy> {
-//     pub start: T,
-//     pub end: T,
-// }
-//
-// impl<T: Copy + core::cmp::PartialOrd + core::cmp::PartialEq + core::ops::Sub<Output = T>>
-//     Range<T>
-// {
-//     pub fn new(start: T, end: T) -> Self {
-//         Self { start, end }
-//     }
-//
-//     pub fn contains(&self, val: T) -> bool {
-//         self.start <= val && val < self.end
-//     }
-//
-//     pub fn size(&self) -> T {
-//         self.end - self.start
-//     }
-// }
+/// A range similar to core::ops::Range but that is copyable.
+/// The range is half-open, inclusive below, exclusive above, ie. [start; end[
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct AddressRange {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl AddressRange {
+    pub fn new<T: Into<usize>>(range: Range<T>) -> Self {
+        let (start, end) = (range.start.into(), range.end.into());
+        // assert!(range.start % page_size == 0);
+        // assert_eq!(range.end, mm::align_up(range.end, page_size));
+
+        assert!(start < end);
+
+        Self { start, end }
+    }
+
+    pub fn with_size(start: usize, size: usize) -> Self {
+        Self::new(start..start + size)
+    }
+
+    pub fn round_up_to_page(self, page_size: usize) -> Self {
+        Self {
+            start: self.start,
+            end: mm::align_up(self.end, page_size),
+        }
+    }
+
+    pub fn iter_pages(self, page_size: usize) -> impl Iterator<Item = usize> {
+        assert_eq!(self.end, mm::align_up(self.end, page_size));
+
+        (self.start..=self.end).step_by(page_size)
+    }
+
+    pub fn count_pages(&self, page_size: usize) -> usize {
+        mm::align_up(self.size(), page_size) / page_size
+    }
+
+    pub fn contains(&self, val: usize) -> bool {
+        self.start <= val && val < self.end
+    }
+
+    pub fn size(&self) -> usize {
+        self.end - self.start
+    }
+}

--- a/hal_riscv64/src/mm/mod.rs
+++ b/hal_riscv64/src/mm/mod.rs
@@ -2,8 +2,8 @@ use core::arch::asm;
 use core::cell::OnceCell;
 
 use hal_core::{
-    mm::{PageAllocFn, PageMap},
-    Error, Range,
+    mm::{self, PageAllocFn, PageMap},
+    AddressRange, Error,
 };
 
 mod sv39;
@@ -18,10 +18,10 @@ pub fn current() -> &'static mut PageTable {
 }
 
 pub fn init_paging(
-    r: impl Iterator<Item = Range>,
-    rw: impl Iterator<Item = Range>,
-    rwx: impl Iterator<Item = Range>,
-    pre_allocated: impl Iterator<Item = Range>,
+    r: impl Iterator<Item = AddressRange>,
+    rw: impl Iterator<Item = AddressRange>,
+    rwx: impl Iterator<Item = AddressRange>,
+    pre_allocated: impl Iterator<Item = AddressRange>,
     alloc: PageAllocFn,
 ) -> Result<(), Error> {
     hal_core::mm::init_paging::<PageTable>(r, rw, rwx, pre_allocated, alloc, |pt| {
@@ -49,4 +49,8 @@ unsafe fn load_pagetable(pt: &'static mut PageTable) {
         asm!("csrw satp, {}", in(reg)u64::from(satp));
         asm!("sfence.vma");
     }
+}
+
+pub fn align_up(addr: usize) -> usize {
+    mm::align_up(addr, PageTable::PAGE_SIZE)
 }

--- a/kernel/src/device_tree.rs
+++ b/kernel/src/device_tree.rs
@@ -1,5 +1,7 @@
 use super::Error;
 
+use hal_core::AddressRange;
+
 use fdt::node::FdtNode;
 
 pub struct DeviceTree {
@@ -19,8 +21,8 @@ impl DeviceTree {
         })
     }
 
-    pub fn memory_region(&self) -> (usize, usize) {
-        (self.addr, self.addr + self.total_size)
+    pub fn memory_region(&self) -> AddressRange {
+        AddressRange::new(self.addr..self.addr + self.total_size)
     }
 
     pub fn for_all_memory_regions<F: FnMut(&mut dyn Iterator<Item = (usize, usize)>)>(


### PR DESCRIPTION
Previously AddressRange was just a type alias to a usize pair. This caused confusion as sometimes it was (addr, size) or (start, end) and lead to a few confusing debugs.

The new type hopefully clear up confusions and make it easy to iterate over the pages in an addressrange.