### PR TITLE
ci: doc: fix unpopulated `--target` argument

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -22,5 +22,5 @@ jobs:
       - name: Build doc
         run: nix develop --command sh -c "
           cd kernel &&
-          cargo doc --target ${{ env.TARGET }} --all-features
+          cargo doc --target ${{ matrix.target }} --all-features
           "


### PR DESCRIPTION
Fixes: 7268ee3a2c3d ("ci: doc: use target matrix")